### PR TITLE
Upgrade to Next.js 16.3 + TS7, audit fixes, e2e, and amount-input/icon crash fix

### DIFF
--- a/apps/org/next.config.ts
+++ b/apps/org/next.config.ts
@@ -115,10 +115,12 @@ const nextConfig: NextConfig = {
         pathname: "/**",
       },
       {
+        // Uniswap + Trust Wallet curated token logos are both served from
+        // raw.githubusercontent.com under different org paths.
         protocol: "https",
         hostname: "raw.githubusercontent.com",
         port: "",
-        pathname: "/Uniswap/assets/master/blockchains/**",
+        pathname: "/**",
       },
       {
         protocol: "https",

--- a/apps/org/src/app/(dashboard)/_components/loan/payment-button.tsx
+++ b/apps/org/src/app/(dashboard)/_components/loan/payment-button.tsx
@@ -1,8 +1,8 @@
-import { parseEther } from "viem"
 import { useAccount } from "wagmi"
 
 import { cn } from "@x7/css"
 import { Button, buttonVariants } from "@x7/ui/button"
+import { safeParseEther } from "@x7/utils"
 import type { ChainId } from "@x7/utils"
 import { usePayLiability } from "~/lib/hooks/tokens/usePayLiability"
 
@@ -29,7 +29,7 @@ export function PaymentButton({
   })
 
   const handlePayment = () => {
-    if (parseEther(amount) > 0) {
+    if (safeParseEther(amount) > 0) {
       // @ts-expect-error: todo fix
       writeContract(data?.request)
     }

--- a/apps/org/src/app/(dashboard)/_components/utilityNfts/details.tsx
+++ b/apps/org/src/app/(dashboard)/_components/utilityNfts/details.tsx
@@ -3,7 +3,7 @@ import Image from "next/image"
 /* oxlint-disable @typescript-eslint/no-unnecessary-condition */
 import { useCallback, useState } from "react"
 import { toast } from "sonner"
-import { formatEther, parseEther } from "viem"
+import { formatEther } from "viem"
 import { useChainId, useReadContracts, useWriteContract } from "wagmi"
 
 import { X7NFT } from "@x7/contracts"
@@ -17,7 +17,7 @@ import {
 } from "@x7/icons"
 import { Button } from "@x7/ui/button"
 import type { ChainId } from "@x7/utils"
-import { generateChainAbbreviation, LogCodes } from "@x7/utils"
+import { generateChainAbbreviation, LogCodes, safeParseEther } from "@x7/utils"
 import { env } from "~/env"
 import { ExplorerDataType, getExplorerLink } from "~/lib/utils/getExplorerLink"
 import { GradientTypes } from "~/lib/utils/gradients"
@@ -79,7 +79,7 @@ export function UtilityNftDetails({ nft }: { nft: UtilityNftType }) {
           abi: X7NFT,
           functionName: "mintMany",
           args: [quantity],
-          value: parseEther(
+          value: safeParseEther(
             // @ts-expect-error: todo fix
             `${parseFloat(formatEther(data?.[1]?.result)) * quantity}`
           ),

--- a/apps/org/src/app/(xchange)/_components/loans/(sections)/loan-launch-price.tsx
+++ b/apps/org/src/app/(xchange)/_components/loans/(sections)/loan-launch-price.tsx
@@ -1,5 +1,4 @@
 /* oxlint-disable @typescript-eslint/no-unnecessary-condition */
-import { parseEther } from "viem"
 // import { ChainLinkAbi } from "@x7/contracts";
 
 import { PinIcon } from "@x7/icons"
@@ -22,7 +21,7 @@ import type { Currency, CurrencyAmount } from "@x7/utils"
 // import type { RouteWithValidQuote } from "@x7/smart-order-router";
 // import { SkeletonBox } from "@x7/ui/skeleton";
 // import { generateChainTokenOracleEtherUSDEnum, Native, WETH9 } from "@x7/utils";
-import { formatUSD } from "@x7/utils"
+import { formatUSD, safeParseEther } from "@x7/utils"
 import { useLoanState } from "~/lib/stores/loan"
 
 interface LoanLaunchPriceProps {
@@ -75,8 +74,8 @@ export function LoanLaunchPrice({
   }
 
   const unitPriceEther =
-    parseInt(parseEther(loanAmount).toString()) /
-    parseInt(parseEther(collateralAmount).toString())
+    parseInt(safeParseEther(loanAmount).toString()) /
+    parseInt(safeParseEther(collateralAmount).toString())
   const etherInUSD = nativePrice
     ? Number(nativePrice.quotient ?? "0") /
       Number(`1e${nativePrice.currency.decimals}`)

--- a/apps/org/src/app/(xchange)/_components/loans/base.tsx
+++ b/apps/org/src/app/(xchange)/_components/loans/base.tsx
@@ -8,7 +8,6 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
 import { toast } from "sonner"
-import { parseEther, parseUnits } from "viem"
 import { useAccount, useChainId } from "wagmi"
 import * as z from "zod"
 
@@ -33,7 +32,13 @@ import {
 } from "@x7/ui/form"
 import { LinkInternal } from "@x7/ui/link"
 import type { ActiveChainId, ChainId } from "@x7/utils"
-import { CurrencyAmount, LogCodes, Native } from "@x7/utils"
+import {
+  CurrencyAmount,
+  LogCodes,
+  Native,
+  safeParseEther,
+  safeParseUnits,
+} from "@x7/utils"
 import { CurrencyInput } from "~/lib/components/utils/currency-input"
 import { SECONDS_IN_A_DAY } from "~/lib/constants/misc"
 import { useGetInitialLiquidityLoan } from "~/lib/hooks/loans/useGetInitialLiquidityLoan"
@@ -125,12 +130,12 @@ export function ILLBaseForm() {
     tokenAddress: (collateralToken?.isNative
       ? ""
       : collateralToken?.address) as `0x${string}`,
-    amount: parseUnits(
+    amount: safeParseUnits(
       collateralAmount,
       collateralToken?.decimals ?? 18
     ).toString(),
     loanTermContractAddress: selectedQuote?.loanTerm.address!,
-    loanAmount: parseUnits(loanAmount, loanToken.decimals), // uint256 loanAmount,
+    loanAmount: safeParseUnits(loanAmount, loanToken.decimals), // uint256 loanAmount,
     loanDuration: BigInt(loanDuration * SECONDS_IN_A_DAY), // uint256 loanDurationSeconds,
     liquidityReceiverAddress: address!, // address liquidityReceiver,
     deadline: deadline.data!, // uint256 deadline
@@ -161,8 +166,8 @@ export function ILLBaseForm() {
       }
 
       const unitPriceEther =
-        parseInt(parseEther(loanAmount).toString()) /
-        parseInt(parseEther(collateralAmount).toString())
+        parseInt(safeParseEther(loanAmount).toString()) /
+        parseInt(safeParseEther(collateralAmount).toString())
       const etherInUSD = nativePrice
         ? Number(nativePrice.quotient ?? "0") /
           Number(`1e${nativePrice.currency.decimals}`)

--- a/apps/org/src/app/(xchange)/fund/_hooks/useX7DMinting.tsx
+++ b/apps/org/src/app/(xchange)/fund/_hooks/useX7DMinting.tsx
@@ -4,7 +4,7 @@ import type { BaseError } from "@wagmi/core"
 import type { Dispatch, SetStateAction } from "react"
 import { useCallback, useMemo, useState } from "react"
 import { toast } from "sonner"
-import { parseEther, UserRejectedRequestError } from "viem"
+import { UserRejectedRequestError } from "viem"
 import {
   useAccount,
   useChainId,
@@ -20,6 +20,7 @@ import { waitForTransactionReceipt } from "wagmi/actions"
 import { X7LendingPoolReserve } from "@x7/contracts"
 import { X7ContractsEnum } from "@x7/sdk"
 import type { ChainId } from "@x7/utils"
+import { safeParseEther } from "@x7/utils"
 import { useNativeCurrency } from "~/lib/hooks/currency/useNativeCurrency"
 import { useTransactionStore } from "~/lib/providers/tx"
 import { useWeb3Config } from "~/lib/providers/web3"
@@ -50,7 +51,7 @@ export const useX7DMinting = ({
     address: lendingPoolReserve,
     abi: X7LendingPoolReserve,
     functionName: "depositETH",
-    value: valueInput ? parseEther(valueInput) : 0n,
+    value: safeParseEther(valueInput),
   })
   const { symbol } = useNativeCurrency({ chainId })
 

--- a/apps/org/src/app/(xchange)/fund/_hooks/useX7DRedeem.tsx
+++ b/apps/org/src/app/(xchange)/fund/_hooks/useX7DRedeem.tsx
@@ -4,7 +4,7 @@ import type { BaseError } from "@wagmi/core"
 import type { Dispatch, SetStateAction } from "react"
 import { useCallback, useMemo, useState } from "react"
 import { toast } from "sonner"
-import { parseEther, UserRejectedRequestError } from "viem"
+import { UserRejectedRequestError } from "viem"
 import {
   useAccount,
   useChainId,
@@ -20,6 +20,7 @@ import { waitForTransactionReceipt } from "wagmi/actions"
 import { X7LendingPoolReserve } from "@x7/contracts"
 import { X7ContractsEnum } from "@x7/sdk"
 import type { ChainId } from "@x7/utils"
+import { safeParseEther } from "@x7/utils"
 import { useNativeCurrency } from "~/lib/hooks/currency/useNativeCurrency"
 import { useTransactionStore } from "~/lib/providers/tx"
 import { useWeb3Config } from "~/lib/providers/web3"
@@ -50,7 +51,7 @@ export const useX7DRedeem = ({
     address: X7ContractsEnum.LendingPoolReserve(chainId),
     abi: X7LendingPoolReserve,
     functionName: "withdrawETH",
-    args: [redeemInput ? parseEther(redeemInput) : 0n],
+    args: [safeParseEther(redeemInput)],
   })
 
   const onSettled = useCallback(

--- a/apps/org/src/lib/components/utils/token-list-content.tsx
+++ b/apps/org/src/lib/components/utils/token-list-content.tsx
@@ -259,7 +259,7 @@ export const TokenListContent: FC<TokenViewProps> = ({
         </div>
       ) : null}
 
-      <List.Control className="relative flex min-h-[256px]! flex-1 grow flex-col gap-3 rounded-none border-0 px-1 py-0.5">
+      <List.Control className="relative flex min-h-0! flex-1 grow flex-col gap-3 overflow-y-auto rounded-none border-0 px-1 py-0.5">
         {isLoading ? (
           <LoadingSkeletons />
         ) : (

--- a/apps/org/src/lib/components/utils/token-selector-dialog.tsx
+++ b/apps/org/src/lib/components/utils/token-selector-dialog.tsx
@@ -70,14 +70,16 @@ export const TokenSelectorDialog: FC<TokenSelectorProps> = ({
   return (
     <Dialog modal={false} open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="flex! min-h-[85vh] flex-col justify-start">
+      <DialogContent className="flex! max-h-[85vh] min-h-[420px] flex-col justify-start overflow-hidden">
         <DialogHeader>
           <DialogTitle>Select a token</DialogTitle>
           <DialogDescription>
             from the default list or search for a token by symbol or address.
           </DialogDescription>
         </DialogHeader>
-        <TokenListContent {...tokenListProps} />
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <TokenListContent {...tokenListProps} />
+        </div>
       </DialogContent>
     </Dialog>
   )

--- a/apps/org/src/lib/hooks/tokens/usePayLiability.tsx
+++ b/apps/org/src/lib/hooks/tokens/usePayLiability.tsx
@@ -4,7 +4,7 @@
 import type { BaseError } from "@wagmi/core"
 import { useCallback, useMemo, useState } from "react"
 import { toast } from "sonner"
-import { parseEther, UserRejectedRequestError } from "viem"
+import { UserRejectedRequestError } from "viem"
 import {
   useAccount,
   useChainId,
@@ -20,6 +20,7 @@ import { waitForTransactionReceipt } from "wagmi/actions"
 import { X7LendingPoolV2 } from "@x7/contracts"
 import { X7ContractsEnum } from "@x7/sdk"
 import type { ChainId } from "@x7/utils"
+import { safeParseEther } from "@x7/utils"
 import { useNativeCurrency } from "~/lib/hooks/currency/useNativeCurrency"
 import { useTransactionStore } from "~/lib/providers/tx"
 
@@ -48,7 +49,7 @@ export const usePayLiability = ({
     address: X7ContractsEnum.X7_LendingPool(chainId),
     abi: X7LendingPoolV2,
     functionName: "payLiability",
-    value: valueInput ? parseEther(valueInput) : 0n,
+    value: safeParseEther(valueInput),
     args: [BigInt(loanId)],
   })
   const { symbol } = useNativeCurrency({ chainId })

--- a/apps/org/src/lib/hooks/tokens/useXchangeTokenListAddToken.tsx
+++ b/apps/org/src/lib/hooks/tokens/useXchangeTokenListAddToken.tsx
@@ -6,7 +6,7 @@ import type { BaseError } from "@wagmi/core"
 import { useCallback, useMemo, useState } from "react"
 import { toast } from "sonner"
 import type { Address } from "viem"
-import { parseEther, UserRejectedRequestError } from "viem"
+import { UserRejectedRequestError } from "viem"
 import {
   useAccount,
   useChainId,
@@ -22,6 +22,7 @@ import { waitForTransactionReceipt } from "wagmi/actions"
 import { tokenRegisteryABI } from "@x7/contracts"
 import { generateChainEtherTokenEnum, X7ContractsEnum } from "@x7/sdk"
 import type { ChainId } from "@x7/utils"
+import { safeParseEther } from "@x7/utils"
 import { useTransactionStore } from "~/lib/providers/tx"
 
 import { useWeb3Config } from "../../providers/web3"
@@ -53,7 +54,7 @@ export const useXchangeTokenListAddToken = ({
     address: X7ContractsEnum.TokenList,
     abi: tokenRegisteryABI,
     functionName: "addToken",
-    value: fee ? parseEther(fee) : 0n,
+    value: safeParseEther(fee),
     args: [tokenAddress, pairedToken, factoryAddress],
   })
 

--- a/apps/org/src/lib/stores/loan/index.ts
+++ b/apps/org/src/lib/stores/loan/index.ts
@@ -10,13 +10,12 @@
 
 import { getPublicClient } from "@wagmi/core"
 import { useCallback, useEffect, useMemo } from "react"
-import { parseUnits } from "viem"
 import { useAccount, useChainId } from "wagmi"
 
 import { X7LendingPoolV2 } from "@x7/contracts"
 import { X7ContractsEnum } from "@x7/sdk"
 import type { ChainId, Currency } from "@x7/utils"
-import { CurrencyAmount, LogCodes, Native } from "@x7/utils"
+import { CurrencyAmount, LogCodes, Native, safeParseUnits } from "@x7/utils"
 import {
   ApprovalState,
   useTokenApproval,
@@ -132,7 +131,7 @@ export function useLoanState(): LoanState {
   const [collateralTokenApprovalState] = useTokenApproval({
     amount: CurrencyAmount.fromRawAmount(
       collateralToken ?? Native.onChain(chainId),
-      parseUnits(collateralAmount, collateralToken?.decimals ?? 18)
+      safeParseUnits(collateralAmount, collateralToken?.decimals ?? 18)
     ),
     spender: X7ContractsEnum.X7_LendingPool(chainId),
     enabled: !!collateralToken && parseFloat(collateralAmount) > 0,
@@ -141,7 +140,7 @@ export function useLoanState(): LoanState {
   const [loanTokenApprovalState] = useTokenApproval({
     amount: CurrencyAmount.fromRawAmount(
       effectiveLoanToken,
-      parseUnits(loanAmount, effectiveLoanToken.decimals)
+      safeParseUnits(loanAmount, effectiveLoanToken.decimals)
     ),
     spender: X7ContractsEnum.X7_LendingPool(chainId),
     enabled: !!effectiveLoanToken && parseFloat(loanAmount) > 0,
@@ -151,13 +150,16 @@ export function useLoanState(): LoanState {
     return [
       {
         token: effectiveLoanToken,
-        amount: parseUnits(loanAmount, effectiveLoanToken.decimals ?? 18),
+        amount: safeParseUnits(loanAmount, effectiveLoanToken.decimals ?? 18),
         address: X7ContractsEnum.X7_LendingPool(chainId),
         approval: loanTokenApprovalState,
       },
       {
         token: collateralToken,
-        amount: parseUnits(collateralAmount, collateralToken?.decimals ?? 18),
+        amount: safeParseUnits(
+          collateralAmount,
+          collateralToken?.decimals ?? 18
+        ),
         address: X7ContractsEnum.X7_LendingPool(chainId),
         approval: collateralTokenApprovalState,
       },
@@ -257,7 +259,7 @@ export function useLoanState(): LoanState {
               args: [
                 address,
                 activeLoanTerms,
-                parseUnits(loanAmount, effectiveLoanToken.decimals),
+                safeParseUnits(loanAmount, effectiveLoanToken.decimals),
                 BigInt(loanDuration * SECONDS_IN_A_DAY),
               ],
             })

--- a/apps/org/src/lib/stores/swap/index.ts
+++ b/apps/org/src/lib/stores/swap/index.ts
@@ -12,7 +12,7 @@ import { watchAccount } from "@wagmi/core"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef } from "react"
 import type { Address } from "viem"
-import { isAddress, parseUnits } from "viem"
+import { isAddress } from "viem"
 import { useAccount, useChainId, useConfig } from "wagmi"
 
 import { X7ContractsEnum } from "@x7/sdk"
@@ -30,6 +30,7 @@ import {
   LogCodes,
   Native,
   pDebounce,
+  safeParseUnits,
   Percent,
   TradeType,
   tryParseAmount,
@@ -194,7 +195,7 @@ export function useSwapState(): SwapState {
     amount: swapAmountString
       ? CurrencyAmount.fromRawAmount(
           _token0 ?? Native.onChain(chainId),
-          parseUnits(swapAmountString, _token0?.decimals ?? 18)
+          safeParseUnits(swapAmountString, _token0?.decimals ?? 18)
         )
       : undefined,
     spender: intendedRouterAddress,
@@ -211,7 +212,7 @@ export function useSwapState(): SwapState {
       token: _token0 ?? Native.onChain(chainId),
       address: intendedRouterAddress,
       amount: swapAmountString
-        ? parseUnits(swapAmountString, _token0?.decimals ?? 18)
+        ? safeParseUnits(swapAmountString, _token0?.decimals ?? 18)
         : 0n,
     }),
     [

--- a/apps/org/src/lib/utils/conversion.ts
+++ b/apps/org/src/lib/utils/conversion.ts
@@ -1,7 +1,9 @@
-import { formatUnits, parseUnits } from "viem"
+import { formatUnits } from "viem"
+
+import { safeParseUnits } from "@x7/utils"
 
 export function fromReadableAmount(amount: number, decimals: number): bigint {
-  return parseUnits(amount.toString(), decimals)
+  return safeParseUnits(amount.toString(), decimals)
 }
 
 export function toReadableAmount(rawAmount: string, decimals: number): string {

--- a/packages/ui/src/currency/currency-icon.tsx
+++ b/packages/ui/src/currency/currency-icon.tsx
@@ -4,7 +4,7 @@
 
 import type { ImageProps } from "next/image"
 import Image from "next/image"
-import { useMemo, useState } from "react"
+import { useMemo } from "react"
 
 import type { Currency } from "@x7/utils"
 import { Chain } from "@x7/utils"
@@ -55,18 +55,17 @@ export const CurrencyIcon = ({
     ""
   )
 
-  const [error, setError] = useState(false)
-
   // Generate fallback background color based on currency details
   const fallbackColor = useMemo(
     () => hashStringToColor(`${currency.symbol} ${currency.name}`),
     [currency.symbol, currency.name]
   )
 
-  // Handle image loading error
+  // Advance to the next candidate source when the current one fails to load.
+  // Once every source is exhausted `imgSrc` becomes undefined and we render
+  // the letter placeholder below.
   const handleError = () => {
-    setError(true)
-    if (nextSrc) nextSrc()
+    nextSrc()
   }
 
   // Convert width/height to numbers with default value
@@ -93,8 +92,8 @@ export const CurrencyIcon = ({
     </div>
   )
 
-  // If we have no image source or encountered an error, show fallback
-  if (!imgSrc || error) {
+  // If every candidate source is exhausted, show the letter placeholder.
+  if (!imgSrc) {
     if (disableLink) {
       return fallbackElement
     }
@@ -122,6 +121,7 @@ export const CurrencyIcon = ({
       }}
     >
       <Image
+        key={imgSrc}
         src={imgSrc}
         alt={`${currency.symbol ?? "Token"} logo`}
         width={widthPx}

--- a/packages/ui/src/hooks/use-token-logo-source.tsx
+++ b/packages/ui/src/hooks/use-token-logo-source.tsx
@@ -1,16 +1,11 @@
-/* oxlint-disable react-hooks/exhaustive-deps */
-/* oxlint-disable @typescript-eslint/no-unused-vars */
-/* oxlint-disable @typescript-eslint/no-unnecessary-condition */
-import { useCallback, useEffect, useState } from "react"
-import { isAddress } from "viem"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { getAddress, isAddress } from "viem"
 
 import { ChainId, ChainNameKey } from "@x7/utils"
 
-import tokenLogoLookup from "../constants/tokenLogoLookup"
-
-// Direct mapping for X7 tokens to ensure they always show up
+// Direct mapping for X7 tokens to ensure they always show up.
+// Keyed by lowercased address for case-insensitive lookup.
 const X7_TOKEN_LOGOS: Record<string, string> = {
-  // Case-insensitive lookup by lowercasing the addresses
   "0x70008f18fc58928dce982b0a69c2c21ff80dca54":
     "https://assets.x7finance.org/images/tokens/x7r.png",
   "0x7105e64bf67eca3ae9b123f0e5ca2b83b2ef2da0":
@@ -29,71 +24,80 @@ const X7_TOKEN_LOGOS: Record<string, string> = {
     "https://assets.x7finance.org/images/tokens/x7d.png",
 }
 
-// Track failed sources to avoid retrying them
-const BAD_SRCS: Record<string, true> = {}
-
-function parseLogoSources(uris: string[]) {
-  const urls: string[] = []
-  uris.forEach((uri) => urls.push(...uriToHttp(uri)))
-  return urls
-}
-
-function prioritizeLogoSources(uris: string[]) {
-  const parsedUris = uris.flatMap((uri) => uriToHttp(uri))
-  const preferredUris: string[] = []
-
-  let coingeckoUrl: string | undefined = undefined
-
-  parsedUris.forEach((uri) => {
-    if (uri.startsWith("https://assets.coingecko")) {
-      if (!coingeckoUrl) {
-        coingeckoUrl = uri.replace(/small|thumb/g, "large")
-      }
-    } else {
-      preferredUris.push(uri)
-    }
-  })
-
-  return coingeckoUrl ? [...preferredUris, coingeckoUrl] : preferredUris
+// Trust Wallet blockchain folder names. These differ from ChainNameKey
+// (e.g. BSC is "smartchain"), so keep a dedicated mapping.
+const TRUSTWALLET_CHAIN: Partial<Record<ChainId, string>> = {
+  [ChainId.ETHEREUM]: "ethereum",
+  [ChainId.BSC]: "smartchain",
+  [ChainId.POLYGON]: "polygon",
+  [ChainId.OPTIMISM]: "optimism",
+  [ChainId.ARBITRUM]: "arbitrum",
+  [ChainId.BASE]: "base",
 }
 
 /**
- * Gets the appropriate logo URL for a token
+ * Builds an ordered, de-duplicated list of candidate logo URLs for a token,
+ * most-likely-correct first. The consumer walks this list, advancing to the
+ * next source whenever an image fails to load.
  */
-function getTokenLogoURL(
+function buildLogoSources(
   address?: `0x${string}` | null,
   chainId?: ChainId | null,
   isNative?: boolean,
   backupImg?: string | null
-): string | undefined {
-  // 1. Handle native tokens (ETH, MATIC, BNB)
-  if (chainId && isNative) {
-    return getNativeLogoURI(chainId)
-  }
-
-  // 2. Check if it's an X7 token (highest priority)
-  if (address) {
-    const lowerCaseAddress = address.toLowerCase()
-    if (X7_TOKEN_LOGOS[lowerCaseAddress]) {
-      return X7_TOKEN_LOGOS[lowerCaseAddress]
+): string[] {
+  const out: string[] = []
+  const push = (uri?: string | null) => {
+    if (!uri) return
+    for (const http of uriToHttp(uri)) {
+      if (!out.includes(http)) out.push(http)
     }
   }
 
-  // 3. Try Uniswap assets repository
-  if (address && isAddress(address)) {
-    const networkName = chainId
-      ? ChainNameKey[chainId as keyof typeof ChainNameKey]
-      : "ethereum"
-
-    return `https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/${networkName}/assets/${address}/logo.png`
+  // Native currency (ETH, MATIC, BNB, …)
+  if (chainId && isNative) {
+    push(getNativeLogoURI(chainId))
+    push(backupImg)
+    return out
   }
 
-  // 4. Use backup image if provided
-  return backupImg ?? undefined
+  if (address && isAddress(address)) {
+    const checksum = getAddress(address)
+
+    // 1. X7 tokens — curated, always available
+    push(X7_TOKEN_LOGOS[address.toLowerCase()])
+
+    // 2. Caller-provided image (e.g. a token-list logoURI)
+    push(backupImg)
+
+    // 3. Uniswap assets repository (requires checksummed address)
+    const uniChain = chainId
+      ? ChainNameKey[chainId as keyof typeof ChainNameKey]
+      : "ethereum"
+    push(
+      `https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/${uniChain}/assets/${checksum}/logo.png`
+    )
+
+    // 4. Trust Wallet assets (requires checksummed address + its own folder)
+    const twChain = chainId ? TRUSTWALLET_CHAIN[chainId] : "ethereum"
+    if (twChain) {
+      push(
+        `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/${twChain}/assets/${checksum}/logo.png`
+      )
+    }
+
+    return out
+  }
+
+  push(backupImg)
+  return out
 }
 
 /**
- * Hook for getting and managing token logo sources with fallbacks
+ * Hook for resolving a token logo with graceful fallbacks. Returns the current
+ * source and a `nextSrc` callback to advance past a source that failed to load.
+ * When every source is exhausted the current value is `undefined`, signalling
+ * the consumer to render its own placeholder.
  */
 export function useAssetLogoSource(
   address?: `0x${string}` | null,
@@ -101,67 +105,23 @@ export function useAssetLogoSource(
   isNative?: boolean,
   backupImg?: string | null
 ): [string | undefined, () => void] {
-  const [current, setCurrent] = useState<string | undefined>(
-    getTokenLogoURL(address, chainId, isNative, backupImg)
+  const sources = useMemo(
+    () => buildLogoSources(address, chainId, isNative, backupImg),
+    [address, chainId, isNative, backupImg]
   )
-  const [fallbackSrcs, setFallbackSrcs] = useState<string[]>([])
 
-  // Update sources when inputs change
+  const [index, setIndex] = useState(0)
+
+  // Restart the fallback walk whenever the candidate list changes.
   useEffect(() => {
-    if (current) {
-      delete BAD_SRCS[current]
-    }
+    setIndex(0)
+  }, [sources])
 
-    // Get primary URL
-    const primaryUrl = getTokenLogoURL(address, chainId, isNative, backupImg)
-    setCurrent(primaryUrl)
-
-    // Setup fallbacks
-    const fallbacks: string[] = []
-
-    // For non-X7 tokens, add some common fallbacks
-    if (address && !X7_TOKEN_LOGOS[address.toLowerCase()]) {
-      // Try Trust Wallet assets
-      fallbacks.push(
-        `https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/${address}/logo.png`
-      )
-
-      // Try CoinGecko if not an X7 token
-      if (address) {
-        fallbacks.push(
-          `https://assets.coingecko.com/coins/images/large/${address.toLowerCase()}.png`
-        )
-      }
-    }
-
-    if (backupImg) {
-      fallbacks.push(backupImg)
-    }
-
-    setFallbackSrcs(fallbacks)
-  }, [address, chainId, isNative, backupImg])
-
-  // Handle fallback when an image fails to load
   const nextSrc = useCallback(() => {
-    if (current) {
-      BAD_SRCS[current] = true
-    }
+    setIndex((i) => i + 1)
+  }, [])
 
-    // Try X7 tokens first (again, just to be sure)
-    if (address) {
-      const x7Logo = X7_TOKEN_LOGOS[address.toLowerCase()]
-      if (x7Logo && !BAD_SRCS[x7Logo]) {
-        setCurrent(x7Logo)
-        return
-      }
-    }
-
-    // Try fallbacks
-    const next = fallbackSrcs.find((src) => !BAD_SRCS[src])
-    setCurrent(next)
-  }, [current, fallbackSrcs, address])
-
-  return [current, nextSrc]
+  return [sources[index], nextSrc]
 }
 
 /**
@@ -194,7 +154,7 @@ function uriToHttp(uri: string): string[] {
       default:
         return []
     }
-  } catch (error) {
+  } catch {
     console.error("Invalid URI:", uri)
     return []
   }

--- a/packages/utils/src/currency/functions/safe-parse-units.ts
+++ b/packages/utils/src/currency/functions/safe-parse-units.ts
@@ -1,0 +1,26 @@
+import { parseUnits } from "viem"
+
+/**
+ * parseUnits() that never throws. viem's parseUnits throws on partial/invalid
+ * decimal strings (e.g. "", ".", "1.", "0.") — which are normal intermediate
+ * states while a user types into an amount field — so calling it directly in
+ * render or a hook crashes the app. Use this for any raw user-entered value.
+ *
+ * Returns 0n for undefined/empty/invalid input.
+ */
+export function safeParseUnits(
+  value: string | undefined | null,
+  decimals: number
+): bigint {
+  if (!value) return 0n
+  try {
+    return parseUnits(value, decimals)
+  } catch {
+    return 0n
+  }
+}
+
+/** safeParseUnits with 18 decimals (native/ETH amounts). */
+export function safeParseEther(value: string | undefined | null): bigint {
+  return safeParseUnits(value, 18)
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -4,6 +4,7 @@ export * from "./debounce"
 
 export * from "./currency"
 export * from "./currency/functions/address-map-to-token-map"
+export * from "./currency/functions/safe-parse-units"
 export * from "./currency/functions/try-parse-amount"
 export * from "./currency/functions/unwrap"
 


### PR DESCRIPTION
## Summary

Brings the monorepo fully current and ship-ready: a complete dependency upgrade, the TypeScript 7 migration, Next.js 16.3 (Cache Components / PPR + instant navigations), a correctness/perf/architecture audit, an e2e overhaul, and offline-resilient token data. The most recent commit fixes a user-reported runtime crash in amount inputs and makes token icons reliable.

## Latest fix — amount-input crash + token icons

**Crash (`Value \`.\` is not a valid decimal number`)**
viem's `parseUnits`/`parseEther` throw on partial decimals (`""`, `"."`, `"1."`, `"0."`) — normal intermediate states while typing — which bubbled to the error boundary.
- Added `safeParseUnits` / `safeParseEther` (`@x7/utils`) that never throw
- Replaced every raw user-input parse site (swap + loan stores, loan form, X7D mint/redeem, pay-liability, add-token, NFT mint, conversion util)

**Token icons**
- Fixed a sticky-error bug in `CurrencyIcon` that permanently rendered the letter placeholder after the first source 404'd, killing the fallback chain
- Rebuilt logo resolution: checksummed addresses, per-chain Trust Wallet folders, dropped the always-404 coingecko-by-address source
- Broadened the `next/image` remote pattern for the Trust Wallet path

**Selector modal** — bounded height with internal scroll instead of a forced 85vh min-height.

## Broader work on this branch

- **Deps + tooling**: full upgrade, pnpm→bun, oxlint/oxfmt, migrate to stable TypeScript 7
- **Next.js 16.3**: Cache Components (PPR), SSR the xchange tree (was fully client-gated), verified zero console errors
- **Correctness/perf/arch**: audit fixes, batched multicall reads, dexie server/client export split, circular-dependency reduction, tree-shaking
- **CI**: hardened + sped up GitHub Actions, turbo cache correctness, cycle detection
- **Testing**: replaced the broken synpress suite with a broad Playwright suite; robust to preview network noise
- **Resilience**: offline-resilient token-list build (RPC + snapshot fallback)

## Verification

`bun run checks` — all 54 tasks green (format + lint + typecheck). Pre-commit hook re-runs typecheck clean.
