### PR TITLE
fix: improve site accessibility

### DIFF
--- a/apps/org/next.config.ts
+++ b/apps/org/next.config.ts
@@ -1,4 +1,95 @@
 import type { NextConfig } from "next"
+import {
+  arbitrum,
+  arbitrumSepolia,
+  base,
+  baseSepolia,
+  bsc,
+  bscTestnet,
+  mainnet,
+  optimism,
+  optimismSepolia,
+  polygon,
+  polygonAmoy,
+  sepolia,
+} from "viem/chains"
+
+const RPC_ENV_KEYS = [
+  "NEXT_PUBLIC_DEFAULT_ETHER_RPC",
+  "NEXT_PUBLIC_DEFAULT_ETHER_RPC_FALLBACK",
+  "NEXT_PUBLIC_DEFAULT_BSC_RPC",
+  "NEXT_PUBLIC_DEFAULT_BSC_RPC_FALLBACK",
+  "NEXT_PUBLIC_DEFAULT_POLY_RPC",
+  "NEXT_PUBLIC_DEFAULT_POLY_RPC_FALLBACK",
+  "NEXT_PUBLIC_DEFAULT_OPTI_RPC",
+  "NEXT_PUBLIC_DEFAULT_OPTI_RPC_FALLBACK",
+  "NEXT_PUBLIC_DEFAULT_ARB_RPC",
+  "NEXT_PUBLIC_DEFAULT_ARB_RPC_FALLBACK",
+  "NEXT_PUBLIC_DEFAULT_BASE_RPC",
+  "NEXT_PUBLIC_DEFAULT_BASE_RPC_FALLBACK",
+  "NEXT_PUBLIC_DEFAULT_ETHER_TESTNET_RPC",
+  "NEXT_PUBLIC_DEFAULT_ETHER_TESTNET_RPC_FALLBACK",
+  "NEXT_PUBLIC_DEFAULT_BSC_TESTNET_RPC",
+  "NEXT_PUBLIC_DEFAULT_BSC_TESTNET_RPC_FALLBACK",
+  "NEXT_PUBLIC_DEFAULT_POLY_TESTNET_RPC",
+  "NEXT_PUBLIC_DEFAULT_POLYGON_TESTNET_RPC_FALLBACK",
+  "NEXT_PUBLIC_DEFAULT_OPTI_TESTNET_RPC",
+  "NEXT_PUBLIC_DEFAULT_OPTIMISM_TESTNET_RPC_FALLBACK",
+  "NEXT_PUBLIC_DEFAULT_ARB_TESTNET_RPC",
+  "NEXT_PUBLIC_DEFAULT_ARBITRUM_TESTNET_RPC_FALLBACK",
+  "NEXT_PUBLIC_DEFAULT_BASE_TESTNET_RPC",
+  "NEXT_PUBLIC_DEFAULT_BASE_TESTNET_RPC_FALLBACK",
+] as const
+
+const SUPPORTED_CHAINS = [
+  mainnet,
+  sepolia,
+  base,
+  baseSepolia,
+  bsc,
+  bscTestnet,
+  polygon,
+  polygonAmoy,
+  optimism,
+  optimismSepolia,
+  arbitrum,
+  arbitrumSepolia,
+] as const
+
+function getRpcOrigin(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  try {
+    const url = new URL(value)
+
+    return ["http:", "https:", "ws:", "wss:"].includes(url.protocol)
+      ? url.origin
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const rpcConnectSources = Array.from(
+  new Set([
+    ...SUPPORTED_CHAINS.flatMap((chain) =>
+      chain.rpcUrls.default.http.map((url) => new URL(url).origin)
+    ),
+    ...RPC_ENV_KEYS.map((key) => getRpcOrigin(process.env[key])).filter(
+      (origin): origin is string => origin !== undefined
+    ),
+    // Established public RPC providers that may be selected as fallbacks.
+    "https://rpc.ankr.com",
+    "https://*.publicnode.com",
+    "https://1rpc.io",
+    "https://*.llamarpc.com",
+    "https://*.quiknode.pro",
+    "https://*.nodereal.io",
+    "https://*.onfinality.io",
+  ])
+)
 
 const nextConfig: NextConfig = {
   // Security headers (migrated from middleware.ts)
@@ -36,6 +127,8 @@ const nextConfig: NextConfig = {
             // connect-src for blockchain RPC providers and web3 services
             [
               "connect-src 'self'",
+              // Configured RPCs, viem defaults, and established public fallbacks
+              ...rpcConnectSources,
               // Alchemy (mainnet and testnets)
               "https://*.alchemy.com",
               "https://*.alchemyapi.io",
@@ -52,7 +145,6 @@ const nextConfig: NextConfig = {
               // Ethereum RPC
               "https://eth.llamarpc.com",
               "https://cloudflare-eth.com",
-              "https://ethereum.reth.rs",
               // WalletConnect
               "wss://*.walletconnect.com",
               "https://*.walletconnect.com",

--- a/apps/org/next.config.ts
+++ b/apps/org/next.config.ts
@@ -52,6 +52,7 @@ const nextConfig: NextConfig = {
               // Ethereum RPC
               "https://eth.llamarpc.com",
               "https://cloudflare-eth.com",
+              "https://ethereum.reth.rs",
               // WalletConnect
               "wss://*.walletconnect.com",
               "https://*.walletconnect.com",

--- a/apps/org/src/app/(dashboard)/_components/contracts/configuration.tsx
+++ b/apps/org/src/app/(dashboard)/_components/contracts/configuration.tsx
@@ -946,7 +946,7 @@ export function Configuration({ contract, chainId }: ConfigurationProps) {
             {allOtherChecksConfigured ? (
               <span className="flex items-center">
                 <CheckCircleIcon className="h-5 w-5 text-emerald-500" />
-                <span className="pl-2 text-sm text-zinc-500">
+                <span className="pl-2 text-sm text-zinc-700 dark:text-zinc-300">
                   View Configuration
                 </span>
               </span>

--- a/apps/org/src/app/(dashboard)/_components/contracts/table.tsx
+++ b/apps/org/src/app/(dashboard)/_components/contracts/table.tsx
@@ -52,7 +52,11 @@ export function ContractsTable({ chainId }: ContractsTableProps) {
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 className="opacity-80 hover:opacity-100"
-                              />
+                              >
+                                <span className="sr-only">
+                                  View {t.name} chart on DexTools
+                                </span>
+                              </LinkExternal>
                             </div>
                           </div>
                         </div>

--- a/apps/org/src/app/(dashboard)/_components/dashboard-subheader.tsx
+++ b/apps/org/src/app/(dashboard)/_components/dashboard-subheader.tsx
@@ -7,15 +7,17 @@ interface SubHeaderProps {
 export function DashboardSubheader(props: SubHeaderProps) {
   const { title, description, id } = props
   return (
-    <div className="mx-4 mb-4 mt-24 border-b border-zinc-900/5 pb-1.5 dark:border-white/5 sm:mb-6 lg:mx-0">
+    <div className="mx-4 mt-24 mb-4 border-b border-zinc-900/5 pb-1.5 sm:mb-6 lg:mx-0 dark:border-white/5">
       <h2
         id={id}
-        className="not-prose mb-1.5 font-heading text-xl font-semibold text-zinc-900 dark:text-zinc-100"
+        className="not-prose font-heading mb-1.5 text-xl font-semibold text-zinc-900 dark:text-zinc-100"
       >
         {title}
       </h2>
       {description && (
-        <p className="text-sm font-medium text-zinc-500">{description}</p>
+        <p className="text-sm font-medium text-zinc-600 dark:text-zinc-400">
+          {description}
+        </p>
       )}
     </div>
   )

--- a/apps/org/src/app/(dashboard)/_components/loan/table.tsx
+++ b/apps/org/src/app/(dashboard)/_components/loan/table.tsx
@@ -136,7 +136,7 @@ export function LoansTable(props: LoanTableProps) {
                       ),
                     },
                     {
-                      header: "",
+                      header: "Actions",
                       accessor: "details",
                       responsive: true,
                       cellRenderer: (t: any) => (

--- a/apps/org/src/app/(dashboard)/dashboard/layout.tsx
+++ b/apps/org/src/app/(dashboard)/dashboard/layout.tsx
@@ -11,10 +11,10 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
     <AppProviders>
       <div className="bg-[#fafafa] dark:bg-[#111111]">
         <DashboardHeader />
-        <div className="dashboard-container">
+        <main className="dashboard-container">
           <div className="flex-1 pb-10 sm:py-10">{children}</div>
-        </div>
-        <SiteFooter className="border-t border-border bg-white dark:bg-black" />
+        </main>
+        <SiteFooter className="border-border border-t bg-white dark:bg-black" />
       </div>
     </AppProviders>
   )

--- a/apps/org/src/app/(docs)/_components/base.tsx
+++ b/apps/org/src/app/(docs)/_components/base.tsx
@@ -118,7 +118,7 @@ export function DocsBase(props: DocsBaseProps) {
                   <LinkInternal
                     prefetch={true}
                     href={previousPage.href}
-                    className="hover:text-muted-foreground text-base font-semibold text-zinc-500 dark:hover:text-zinc-300"
+                    className="text-base font-semibold text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-300"
                   >
                     <span aria-hidden="true">&larr;</span> {previousPage.title}
                   </LinkInternal>
@@ -134,7 +134,7 @@ export function DocsBase(props: DocsBaseProps) {
                   <LinkInternal
                     prefetch={true}
                     href={nextPage.href}
-                    className="hover:text-muted-foreground text-base font-semibold text-zinc-500 dark:hover:text-zinc-300"
+                    className="text-base font-semibold text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-300"
                   >
                     {nextPage.title} <span aria-hidden="true">&rarr;</span>
                   </LinkInternal>

--- a/apps/org/src/app/(docs)/_components/navigation.tsx
+++ b/apps/org/src/app/(docs)/_components/navigation.tsx
@@ -36,7 +36,10 @@ export function Navigation({ navigation, className }: NavigationProps) {
   const pathname = usePathname()
 
   return (
-    <nav className={cn("text-base lg:text-sm", className)}>
+    <nav
+      aria-label="Documentation navigation"
+      className={cn("text-base lg:text-sm", className)}
+    >
       <SectionNavigation className="mb-6 space-y-1" />
       <ul className="space-y-9">
         {navigation.map((section) =>

--- a/apps/org/src/app/(docs)/docs/layout.tsx
+++ b/apps/org/src/app/(docs)/docs/layout.tsx
@@ -11,9 +11,9 @@ export default function DocsLayout({ children }: DocsLayoutProps) {
     <AppProviders>
       <div className="bg-[#fafafa] dark:bg-[#111111]">
         <DashboardHeader />
-        <div className="dashboard-container">
+        <main className="dashboard-container">
           <div className="flex-1">{children}</div>
-        </div>
+        </main>
         <SiteFooter className="border-t border-zinc-200 bg-white dark:border-zinc-800 dark:bg-black" />
       </div>
     </AppProviders>

--- a/apps/org/src/app/(marketing)/about/page.tsx
+++ b/apps/org/src/app/(marketing)/about/page.tsx
@@ -26,7 +26,7 @@ export default function AboutPage() {
           <div className="mx-auto max-w-4xl">
             <div className="mb-8 flex items-center space-x-2">
               <div className="h-px flex-1 bg-zinc-300 dark:bg-zinc-700"></div>
-              <span className="font-mono text-xs tracking-wider text-zinc-500 uppercase">
+              <span className="font-mono text-xs tracking-wider text-zinc-600 uppercase dark:text-zinc-400">
                 X7 Finance
               </span>
               <div className="h-px flex-1 bg-zinc-300 dark:bg-zinc-700"></div>
@@ -37,7 +37,7 @@ export default function AboutPage() {
             </h1>
 
             <div className="mt-4 mb-8 font-mono text-sm text-zinc-500">
-              <code className="rounded bg-zinc-100 px-1.5 py-0.5 dark:bg-zinc-800">
+              <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
                 trust code, not institutions
               </code>
             </div>
@@ -82,7 +82,7 @@ export default function AboutPage() {
           <div className="mx-auto max-w-4xl">
             <div className="mb-8 flex items-center space-x-2">
               <div className="h-px w-12 bg-zinc-300 dark:bg-zinc-700"></div>
-              <span className="font-mono text-xs tracking-wider text-zinc-500 uppercase">
+              <span className="font-mono text-xs tracking-wider text-zinc-600 uppercase dark:text-zinc-400">
                 Current Infrastructure
               </span>
             </div>
@@ -100,7 +100,10 @@ export default function AboutPage() {
                 optimal routing across deep liquidity pools while prioritizing
                 user privacy and security.
               </p>
-              <pre className="mb-6 overflow-x-auto rounded-md bg-zinc-100 p-4 text-sm dark:bg-zinc-800/50 dark:text-zinc-300">
+              <pre
+                tabIndex={0}
+                className="mb-6 overflow-x-auto rounded-md bg-zinc-100 p-4 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 dark:bg-zinc-800/50 dark:text-zinc-300"
+              >
                 <code>{`// Key features
 const XchangeFeatures = {
   highLiquidity: "Deep pools for minimal slippage",
@@ -130,7 +133,10 @@ const XchangeFeatures = {
                 launch with substantial liquidity while preserving their startup
                 capital.
               </p>
-              <pre className="mb-6 overflow-x-auto rounded-md bg-zinc-100 p-4 text-sm dark:bg-zinc-800/50 dark:text-zinc-300">
+              <pre
+                tabIndex={0}
+                className="mb-6 overflow-x-auto rounded-md bg-zinc-100 p-4 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 dark:bg-zinc-800/50 dark:text-zinc-300"
+              >
                 <code>{`// Contract interface
 interface ILeveragedLoan {
   function initiateLoan(
@@ -161,7 +167,7 @@ interface ILeveragedLoan {
           <div className="mx-auto max-w-4xl">
             <div className="mb-8 flex items-center space-x-2">
               <div className="h-px w-12 bg-zinc-300 dark:bg-zinc-700"></div>
-              <span className="font-mono text-xs tracking-wider text-zinc-500 uppercase">
+              <span className="font-mono text-xs tracking-wider text-zinc-600 uppercase dark:text-zinc-400">
                 Development Roadmap
               </span>
             </div>
@@ -177,7 +183,10 @@ interface ILeveragedLoan {
               production.
             </p>
 
-            <pre className="mb-10 overflow-x-auto rounded-md bg-zinc-100 p-4 font-mono text-sm dark:bg-zinc-800/50 dark:text-zinc-300">
+            <pre
+              tabIndex={0}
+              className="mb-10 overflow-x-auto rounded-md bg-zinc-100 p-4 font-mono text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 dark:bg-zinc-800/50 dark:text-zinc-300"
+            >
               <code>{`// Development status
 const roadmapStatus = {
   PLANNING: "Early research and requirements gathering",
@@ -205,7 +214,10 @@ const roadmapStatus = {
                   bootstrapping their projects regardless of their preferred DEX
                   or blockchain.
                 </p>
-                <pre className="mt-4 mb-4 overflow-x-auto rounded-md bg-zinc-100 p-4 text-sm dark:bg-zinc-800/50 dark:text-zinc-300">
+                <pre
+                  tabIndex={0}
+                  className="mt-4 mb-4 overflow-x-auto rounded-md bg-zinc-100 p-4 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 dark:bg-zinc-800/50 dark:text-zinc-300"
+                >
                   <code>{`// Cross-DEX adapter example
 interface ICrossDexAdapter {
   function initiateLoanOnDex(
@@ -288,7 +300,7 @@ interface ICrossDexAdapter {
           <div className="mx-auto max-w-4xl">
             <div className="mb-8 flex items-center space-x-2">
               <div className="h-px w-12 bg-zinc-300 dark:bg-zinc-700"></div>
-              <span className="font-mono text-xs tracking-wider text-zinc-500 uppercase">
+              <span className="font-mono text-xs tracking-wider text-zinc-600 uppercase dark:text-zinc-400">
                 Open Source
               </span>
             </div>
@@ -331,7 +343,10 @@ interface ICrossDexAdapter {
               </LinkExternal>
             </div>
 
-            <pre className="mb-6 overflow-x-auto rounded-md bg-zinc-100 p-4 font-mono text-sm dark:bg-zinc-800/50 dark:text-zinc-300">
+            <pre
+              tabIndex={0}
+              className="mb-6 overflow-x-auto rounded-md bg-zinc-100 p-4 font-mono text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 dark:bg-zinc-800/50 dark:text-zinc-300"
+            >
               <code>{`// How to contribute
 const contributionPath = {
   1: "Fork the repository",
@@ -362,7 +377,7 @@ const contributionPath = {
           <div className="mx-auto max-w-4xl">
             <div className="mb-8 flex items-center space-x-2">
               <div className="h-px w-12 bg-zinc-300 dark:bg-zinc-700"></div>
-              <span className="font-mono text-xs tracking-wider text-zinc-500 uppercase">
+              <span className="font-mono text-xs tracking-wider text-zinc-600 uppercase dark:text-zinc-400">
                 Governance
               </span>
             </div>
@@ -380,7 +395,10 @@ const contributionPath = {
               capital available for all humans and machines.
             </p>
 
-            <pre className="mb-10 overflow-x-auto rounded-md bg-zinc-100 p-4 font-mono text-sm dark:bg-zinc-800/50 dark:text-zinc-300">
+            <pre
+              tabIndex={0}
+              className="mb-10 overflow-x-auto rounded-md bg-zinc-100 p-4 font-mono text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 dark:bg-zinc-800/50 dark:text-zinc-300"
+            >
               <code>{`// DAO governance structure
 const governanceStructure = {
   token: "X7DAO",

--- a/apps/org/src/app/(xchange)/(whiteboard)/index.tsx
+++ b/apps/org/src/app/(xchange)/(whiteboard)/index.tsx
@@ -5,13 +5,7 @@ import { useState } from "react"
 
 // import { cn } from "@x7/css";
 // import { buttonVariants } from "@x7/ui/button";
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@x7/ui/card"
+import { Card, CardContent, CardFooter, CardHeader } from "@x7/ui/card"
 // import { Input } from "@x7/ui/input";
 // import {
 //   Select,
@@ -117,10 +111,13 @@ export function XChangeBoard() {
                         <div className="absolute right-2 bottom-8 h-16 w-16 overflow-hidden rounded-lg shadow-xs">
                           <SkeletonBox className="h-full w-full" />
                         </div>
-                        <CardTitle className="p-3 pt-1 text-sm font-bold">
+                        <div
+                          aria-hidden="true"
+                          className="p-3 pt-1 text-sm font-bold"
+                        >
                           <SkeletonBox className="mb-1 h-5 w-32" />
                           <SkeletonBox className="h-4 w-24" />
-                        </CardTitle>
+                        </div>
                       </CardHeader>
                       <CardContent className="text-2xs grow space-y-2 px-3 py-1">
                         <SkeletonBox className="h-12 w-full" />

--- a/apps/org/src/app/(xchange)/(whiteboard)/page.tsx
+++ b/apps/org/src/app/(xchange)/(whiteboard)/page.tsx
@@ -24,7 +24,7 @@ export default function XchangeSwapPage() {
   return (
     <CheckerProviderComponent>
       <div className="relative mx-auto w-full max-w-7xl px-2 sm:px-6 lg:px-8">
-        <main className="w-full flex-1">
+        <div className="w-full flex-1">
           <div className="my-8 flex flex-col items-center">
             <SubtleGlowBg className="w-full sm:max-w-md">
               <XChangeSwap />
@@ -34,7 +34,7 @@ export default function XchangeSwapPage() {
               <TradeLines />
             </SubtleGlowBg>
           </div>
-        </main>
+        </div>
       </div>
     </CheckerProviderComponent>
   )

--- a/apps/org/src/app/(xchange)/_components/mobile-nav.tsx
+++ b/apps/org/src/app/(xchange)/_components/mobile-nav.tsx
@@ -12,9 +12,20 @@ import {
   Twitter,
   Warpcast,
   X7Logo,
+  XIcon,
 } from "@x7/icons"
-import { Collapsible, CollapsibleContent } from "@x7/ui/collapsible"
-import { Drawer, DrawerContent, DrawerTrigger } from "@x7/ui/drawer"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@x7/ui/collapsible"
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@x7/ui/drawer"
 import { LinkExternal, LinkInternal } from "@x7/ui/link"
 import { SocialsEnum } from "@x7/utils"
 import {
@@ -116,14 +127,23 @@ export function MobileNav() {
 
   return (
     <Drawer open={isOpen} onOpenChange={setIsOpen}>
-      <DrawerTrigger
-        aria-label="Open menu"
-        className="flex items-center justify-center"
-      >
-        <TextIcon className="text-muted-foreground h-6 w-6" />
-        <ChevronDownIcon className="text-muted-foreground h-3 w-3" />
+      <DrawerTrigger className="flex items-center justify-center">
+        <span className="sr-only">Open navigation menu</span>
+        <TextIcon
+          aria-hidden="true"
+          className="text-muted-foreground h-6 w-6"
+        />
+        <ChevronDownIcon
+          aria-hidden="true"
+          className="text-muted-foreground h-3 w-3"
+        />
       </DrawerTrigger>
-      <DrawerContent className="">
+      <DrawerContent>
+        <DrawerTitle className="sr-only">Xchange navigation</DrawerTitle>
+        <DrawerClose className="focus-visible:ring-ring absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden">
+          <XIcon aria-hidden="true" className="h-5 w-5" />
+          <span className="sr-only">Close navigation</span>
+        </DrawerClose>
         <div className="space-y-4 p-4">
           <div>
             <div className="flex w-full items-center justify-between text-lg">
@@ -157,34 +177,31 @@ export function MobileNav() {
             </div>
           </div>
           {navSections.map((section) => (
-            <div key={section.title}>
-              <button
-                className="flex w-full items-center justify-between text-lg"
-                onClick={() =>
-                  setOpenSection(
-                    openSection === section.title ? null : section.title
-                  )
-                }
-              >
+            <Collapsible
+              key={section.title}
+              open={openSection === section.title}
+              onOpenChange={(open) =>
+                setOpenSection(open ? section.title : null)
+              }
+            >
+              <CollapsibleTrigger className="flex w-full items-center justify-between text-lg">
                 <span className="font-heading">{section.title}</span>
-                <ChevronDownIcon className="h-4 w-4" />
-              </button>
-              <Collapsible open={openSection === section.title}>
-                <CollapsibleContent className="mt-2 space-y-1">
-                  {section.items.map((item) => (
-                    <LinkInternal
-                      prefetch={true}
-                      key={item.label}
-                      href={item.href}
-                      onClick={closeDrawer}
-                      className="text-muted-foreground ml-2 block"
-                    >
-                      {item.label}
-                    </LinkInternal>
-                  ))}
-                </CollapsibleContent>
-              </Collapsible>
-            </div>
+                <ChevronDownIcon aria-hidden="true" className="h-4 w-4" />
+              </CollapsibleTrigger>
+              <CollapsibleContent className="mt-2 space-y-1">
+                {section.items.map((item) => (
+                  <LinkInternal
+                    prefetch={true}
+                    key={item.label}
+                    href={item.href}
+                    onClick={closeDrawer}
+                    className="text-muted-foreground ml-2 block"
+                  >
+                    {item.label}
+                  </LinkInternal>
+                ))}
+              </CollapsibleContent>
+            </Collapsible>
           ))}
 
           <div className="text-muted-foreground mt-4 flex justify-center space-x-4">
@@ -214,7 +231,8 @@ export function MobileNav() {
                 rel="noopener noreferrer"
                 className="flex items-center justify-between py-2 font-medium"
               >
-                <item.icon className="h-5 w-5" />
+                <span className="sr-only">X7 Finance on {item.label}</span>
+                <item.icon aria-hidden="true" className="h-5 w-5" />
               </LinkExternal>
             ))}
           </div>

--- a/apps/org/src/app/(xchange)/_components/nav-items.tsx
+++ b/apps/org/src/app/(xchange)/_components/nav-items.tsx
@@ -54,7 +54,7 @@ export function NavItems() {
   }
 
   return (
-    <NavigationMenu>
+    <NavigationMenu aria-label="Xchange navigation">
       <NavigationMenuList>
         <NavigationMenuItem>
           <NavigationMenuLink asChild>

--- a/apps/org/src/app/(xchange)/_components/swap/drpc-partner.tsx
+++ b/apps/org/src/app/(xchange)/_components/swap/drpc-partner.tsx
@@ -9,8 +9,12 @@ export function DrpcPartner() {
         target="_blank"
         className="group"
         href="https://drpc.org?ref=9bf02d"
+        aria-label="Powered by dRPC"
       >
-        <PoweredByDrpc className="h-10 w-32 opacity-40 transition-opacity duration-300 group-hover:opacity-100 sm:w-40" />
+        <PoweredByDrpc
+          aria-hidden="true"
+          className="h-10 w-32 opacity-40 transition-opacity duration-300 group-hover:opacity-100 sm:w-40"
+        />
       </LinkExternal>
     </div>
   )

--- a/apps/org/src/app/(xchange)/_components/swap/swap-flip-button.tsx
+++ b/apps/org/src/app/(xchange)/_components/swap/swap-flip-button.tsx
@@ -11,6 +11,7 @@ export function FlipSwapTokensButton({ onClick }: { onClick: () => void }) {
       >
         <div className="rotate-0 transition-transform group-hover:rotate-180">
           <ArrowUpDownIcon
+            aria-hidden="true"
             strokeWidth={3}
             className="h-4 w-4 text-muted-foreground"
           />

--- a/apps/org/src/app/(xchange)/_components/swap/swap-form.tsx
+++ b/apps/org/src/app/(xchange)/_components/swap/swap-form.tsx
@@ -185,7 +185,9 @@ export function X7SwapForm(props: X7SwapFormProps) {
         actionType="Buy"
       />
       <div className="mb-2">
-        <div className="my-2 text-xs text-zinc-500">Quick Buy</div>
+        <div className="my-2 text-xs text-zinc-600 dark:text-zinc-400">
+          Quick Buy
+        </div>
         <div className="flex flex-wrap gap-2">
           {QUICK_BUY_AMOUNTS.map((amount) => (
             <Button

--- a/apps/org/src/app/(xchange)/_components/x7d/base.tsx
+++ b/apps/org/src/app/(xchange)/_components/x7d/base.tsx
@@ -94,7 +94,7 @@ export function X7DFunding() {
   return (
     <Card className="mx-auto mt-6 max-w-2xl">
       <CardHeader className="space-y-1 px-3 sm:px-6">
-        <CardTitle className="mb-2 text-zinc-900 dark:text-zinc-100">
+        <CardTitle tag="h2" className="mb-2 text-zinc-900 dark:text-zinc-100">
           X7D Funding
         </CardTitle>
         <CardDescription className="text-muted-foreground">
@@ -113,7 +113,7 @@ export function X7DFunding() {
               </span>
             )}
           </div>
-          <div className="flex h-full items-end text-sm font-bold tracking-widest text-muted-foreground">
+          <div className="text-muted-foreground flex h-full items-end text-sm font-bold tracking-widest">
             {X7D[chainId]?.name ?? "X7D"} BALANCE
           </div>
         </div>

--- a/apps/org/src/app/(xchange)/create/_components/create-coin-form.tsx
+++ b/apps/org/src/app/(xchange)/create/_components/create-coin-form.tsx
@@ -260,7 +260,7 @@ export function CreateCoinForm() {
   return (
     <Card className="mx-auto mt-8 max-w-lg transition-colors duration-300 hover:border-emerald-500 focus:z-20">
       <CardHeader>
-        <CardTitle>Create Coin</CardTitle>
+        <CardTitle tag="h2">Create Coin</CardTitle>
       </CardHeader>
       <CardContent>
         <Form {...form}>
@@ -319,11 +319,12 @@ export function CreateCoinForm() {
               name="tokenURI"
               render={({ field: { value, onChange, ...field } }) => (
                 <FormItem>
-                  <FormLabel>Coin Logo</FormLabel>
+                  <FormLabel htmlFor="coin-logo">Coin Logo</FormLabel>
                   <FormControl>
                     <div className="space-y-4">
                       <div className="border-border hover:border-primary/50 flex min-h-[80px] w-full items-center justify-center rounded-md border-2 border-dashed p-4">
                         <Input
+                          id="coin-logo"
                           type="file"
                           accept="image/*"
                           onChange={handleFileChange}

--- a/apps/org/src/app/(xchange)/create/page.tsx
+++ b/apps/org/src/app/(xchange)/create/page.tsx
@@ -20,13 +20,13 @@ export default function CreateCoinPage() {
   return (
     <CheckerProviderComponent>
       <div className="relative mx-auto px-2 sm:px-6 lg:px-8">
-        <main className="flex-1">
+        <div className="flex-1">
           <div className="flex justify-center">
             <div className="flex flex-col items-center justify-center">
               <CreateBase />
             </div>
           </div>
-        </main>
+        </div>
       </div>
     </CheckerProviderComponent>
   )

--- a/apps/org/src/app/(xchange)/layout.tsx
+++ b/apps/org/src/app/(xchange)/layout.tsx
@@ -22,15 +22,25 @@ async function XchangeContent({ children }: { children: ReactNode }) {
     <AppProviders initialState={initialState}>
       <div className="h-full">
         <div className="flex min-h-dvh flex-col">
-          <nav className="fixed top-0 right-0 left-0 z-100 flex h-12 items-center border-b border-zinc-300 bg-zinc-50 px-4 sm:h-16 md:px-8 dark:border-zinc-700 dark:bg-zinc-900">
+          <header className="fixed top-0 right-0 left-0 z-100 flex h-12 items-center border-b border-zinc-300 bg-zinc-50 px-4 sm:h-16 md:px-8 dark:border-zinc-700 dark:bg-zinc-900">
             <div className="mr-4 items-center lg:mr-8">
-              <LinkInternal prefetch={true} href="/">
-                <Xchange className="fill-foreground mr-0 hidden h-6 w-auto md:flex" />
-                <X7Logo className="fill-foreground h-6 w-auto md:hidden" />
+              <LinkInternal
+                prefetch={true}
+                href="/"
+                aria-label="X7 Finance home"
+              >
+                <Xchange
+                  aria-hidden="true"
+                  className="fill-foreground mr-0 hidden h-6 w-auto md:flex"
+                />
+                <X7Logo
+                  aria-hidden="true"
+                  className="fill-foreground h-6 w-auto md:hidden"
+                />
               </LinkInternal>
             </div>
-            <MainNav />
-          </nav>
+            <MainNav aria-label="Primary navigation" />
+          </header>
 
           <main className="flex-1">
             <div className="relative ml-0 flex flex-auto flex-col 2xl:flex 2xl:items-center">

--- a/apps/org/src/app/(xchange)/liquidity/_components/livePairs/row.tsx
+++ b/apps/org/src/app/(xchange)/liquidity/_components/livePairs/row.tsx
@@ -135,6 +135,7 @@ export function PairRow({ id, type }: PairsProps) {
                 )}/pair-explorer/${contractAddress}`}
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label={`View ${tokenSymbol ?? "token"} pair on DexTools`}
                 key={`${contractAddress}-${id}-chart`}
                 className="flex h-full w-full items-center justify-center opacity-80 hover:opacity-100"
               >

--- a/apps/org/src/app/(xchange)/swap/page.tsx
+++ b/apps/org/src/app/(xchange)/swap/page.tsx
@@ -20,13 +20,13 @@ export default function XchangeSwapPage() {
   return (
     <CheckerProviderComponent>
       <div className="relative mx-auto px-2 sm:px-6 lg:px-8">
-        <main className="flex-1">
+        <div className="flex-1">
           <div className="flex justify-center">
             <div className="flex w-full flex-col items-center justify-center">
               <XChangeSwap />
             </div>
           </div>
-        </main>
+        </div>
       </div>
     </CheckerProviderComponent>
   )

--- a/apps/org/src/lib/components/core/animate-tabs.tsx
+++ b/apps/org/src/lib/components/core/animate-tabs.tsx
@@ -149,7 +149,7 @@ export function AnimatedTabs({
         >
           <button
             className={cn(
-              "text-md relative z-20 flex h-8 cursor-pointer items-center rounded-lg bg-transparent px-4 text-sm whitespace-nowrap text-zinc-500 transition-colors select-none",
+              "text-md relative z-20 flex h-8 cursor-pointer items-center rounded-lg bg-transparent px-4 text-sm whitespace-nowrap text-zinc-600 transition-colors select-none dark:text-zinc-400",
               isMobile && "w-full justify-center",
               {
                 "text-black dark:text-white":

--- a/apps/org/src/lib/components/core/dashboard-header.tsx
+++ b/apps/org/src/lib/components/core/dashboard-header.tsx
@@ -11,7 +11,10 @@ import { MobileNavigation } from "./mobile-navigation"
 export function DashboardHeader() {
   return (
     <>
-      <nav className="sticky z-10 h-14 w-full">
+      <nav
+        aria-label="Dashboard navigation"
+        className="sticky z-10 h-14 w-full"
+      >
         <div className="fixed bg-white px-3 py-3 lg:px-5 lg:pl-3 dark:bg-black">
           <div className="flex items-center justify-between">
             <div
@@ -49,8 +52,11 @@ function LogoMarkLink() {
   return (
     <div className="flex items-center">
       <div className="ml-3 flex items-center">
-        <LinkInternal prefetch={true} href="/">
-          <X7Logo className="mr-3 h-8 fill-black dark:fill-white" />
+        <LinkInternal prefetch={true} href="/" aria-label="X7 Finance home">
+          <X7Logo
+            aria-hidden="true"
+            className="mr-3 h-8 fill-black dark:fill-white"
+          />
         </LinkInternal>
       </div>
     </div>

--- a/apps/org/src/lib/components/core/mirrored-sites.tsx
+++ b/apps/org/src/lib/components/core/mirrored-sites.tsx
@@ -15,8 +15,11 @@ export function MirroredSites() {
     <div className="flex justify-center">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <button type="button" aria-label="Mirror sites">
-            <BoxesIcon className="text-secondary-foreground h-4 w-4" />
+          <button type="button" aria-label="View mirrored sites">
+            <BoxesIcon
+              aria-hidden="true"
+              className="text-secondary-foreground h-4 w-4"
+            />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="rounded-lg bg-white p-4 text-zinc-800 shadow-lg dark:bg-zinc-800 dark:text-zinc-200">

--- a/apps/org/src/lib/components/core/mobile-navigation.tsx
+++ b/apps/org/src/lib/components/core/mobile-navigation.tsx
@@ -1,14 +1,14 @@
 import React from "react"
 
 import { cn } from "@x7/css"
-import { TextIcon, X7LongLogo, XIcon } from "@x7/icons"
+import { TextIcon, X7LongLogo } from "@x7/icons"
 import { buttonVariants } from "@x7/ui/button"
 import { LinkInternal } from "@x7/ui/link"
 import {
   Sheet,
   SheetClose,
   SheetContent,
-  SheetHeader,
+  SheetTitle,
   SheetTrigger,
 } from "@x7/ui/sheet"
 import { MOBILE_NAV_LINKS } from "~/lib/config/site"
@@ -22,22 +22,22 @@ export function MobileNavigation({ className }: { className?: string }) {
       <SheetTrigger asChild>
         <button
           type="button"
-          aria-label="Open menu"
+          aria-label="Open navigation menu"
           className={cn(
             "relative z-40 -m-2 inline-flex items-center rounded-lg border border-zinc-600 stroke-zinc-900 p-1 text-black hover:bg-zinc-200/50 hover:stroke-zinc-600 focus-visible:outline-emerald-500 active:stroke-zinc-900 sm:p-2 dark:stroke-zinc-100 dark:text-white dark:hover:bg-zinc-800/50 dark:hover:stroke-zinc-500 dark:active:stroke-zinc-100",
             className
           )}
         >
-          <TextIcon data-slot="icon" className="h-6 w-6 rotate-180" />
+          <TextIcon
+            aria-hidden="true"
+            data-slot="icon"
+            className="h-6 w-6 rotate-180"
+          />
         </button>
       </SheetTrigger>
       <SheetContent side="left" className="w-full max-w-80 p-0 lg:hidden">
+        <SheetTitle className="sr-only">Navigation</SheetTitle>
         <div className="flex h-full flex-col rounded-lg bg-white shadow-xs ring-1 ring-zinc-950/5 dark:bg-zinc-900 dark:ring-white/10">
-          <SheetHeader className="-mb-3 ml-auto px-4 pt-3">
-            <SheetClose aria-label="Close menu" className="ml-auto">
-              <XIcon data-slot="icon" className="h-6 w-6" />
-            </SheetClose>
-          </SheetHeader>
           <div className="mb-8 flex items-center px-4 pt-4">
             <X7LongLogo className="w-36 text-black dark:text-white" />
           </div>
@@ -56,7 +56,7 @@ export function MobileNavigation({ className }: { className?: string }) {
           </div>
           <div className="mt-8 flex flex-col gap-4 px-4 text-black dark:text-white">
             <ThemeToggle />
-            <div className="text-center text-xs text-zinc-500 italic">
+            <div className="text-center text-xs text-zinc-600 italic dark:text-zinc-400">
               Trust No One. Trust Code. Long Live DeFi
             </div>
           </div>

--- a/apps/org/src/lib/components/core/settings/index.tsx
+++ b/apps/org/src/lib/components/core/settings/index.tsx
@@ -1,8 +1,7 @@
-/* oxlint-disable @typescript-eslint/prefer-nullish-coalescing */
 "use client"
 
-import type { FC, ReactNode } from "react"
-import { useMemo, useState } from "react"
+import type { FC, ReactElement } from "react"
+import { useMemo } from "react"
 
 import { SlidersVerticalIcon, XIcon } from "@x7/icons"
 import { useSlippageTolerance } from "@x7/ui"
@@ -29,7 +28,7 @@ export enum SettingsModule {
 }
 
 interface SettingsOverlayProps {
-  children?: ReactNode
+  children?: ReactElement
   modules: SettingsModule[]
   options?: {
     slippageTolerance?: {
@@ -58,7 +57,6 @@ export const SettingsOverlay: FC<SettingsOverlayProps> = ({
   children,
   options,
 }) => {
-  const [_open, setOpen] = useState(false)
   const [slippageTolerance, setSlippageTolerance] = useSlippageTolerance(
     options?.slippageTolerance?.storageKey
   )
@@ -81,63 +79,64 @@ export const SettingsOverlay: FC<SettingsOverlayProps> = ({
 
   return (
     <Dialog>
-      <DialogTrigger asChild nativeButton={false}>
-        {children || (
-          <div
-            onClick={() => setOpen(true)}
-            className="ml-auto flex cursor-pointer items-center rounded-lg border border-border bg-muted/50 px-2 py-1 text-2xs"
-          >
-            <div className="flex items-center font-bold text-muted-foreground">
-              {singleDex ? (
-                <ImplementationIcon
-                  implementation={singleDex}
-                  classNameOverrides={implementationClassOverrides}
-                />
-              ) : (
-                <>
-                  <span className="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-green-500"></span>
-                  {dexCount} Dexs
-                </>
-              )}
-            </div>
-            {highSlippage &&
-              modules.includes(SettingsModule.SlippageTolerance) && (
-                <>
-                  <div className="mx-2 text-muted-foreground/30">|</div>
-                  <Tooltip delayDuration={150}>
-                    <TooltipTrigger asChild>
-                      <Button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          setSlippageTolerance("0.5")
-                        }}
-                        className="h-6 rounded-xs bg-opacity-50 text-black"
-                        iconPosition="end"
-                        variant="warning"
-                        size="xs"
-                        icon={XIcon}
-                      >
-                        {slippageTolerance}%
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>Reset slippage tolerance</TooltipContent>
-                  </Tooltip>
-                </>
-              )}
-            <div className="ml-2 text-muted-foreground/30">|</div>
+      {children ? (
+        <DialogTrigger asChild>{children}</DialogTrigger>
+      ) : (
+        <div className="border-border bg-muted/50 text-2xs ml-auto flex items-center rounded-lg border px-2 py-1">
+          <div className="text-muted-foreground flex items-center font-bold">
+            {singleDex ? (
+              <ImplementationIcon
+                implementation={singleDex}
+                classNameOverrides={implementationClassOverrides}
+              />
+            ) : (
+              <>
+                <span className="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-green-500"></span>
+                {dexCount} Dexs
+              </>
+            )}
+          </div>
+          {highSlippage &&
+            modules.includes(SettingsModule.SlippageTolerance) && (
+              <>
+                <div aria-hidden="true" className="text-muted-foreground mx-2">
+                  |
+                </div>
+                <Tooltip delayDuration={150}>
+                  <TooltipTrigger asChild>
+                    <Button
+                      onClick={() => setSlippageTolerance("0.5")}
+                      className="bg-opacity-50 h-6 rounded-xs text-black"
+                      iconPosition="end"
+                      variant="warning"
+                      size="xs"
+                      icon={XIcon}
+                    >
+                      {slippageTolerance}%
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Reset slippage tolerance</TooltipContent>
+                </Tooltip>
+              </>
+            )}
+          <div aria-hidden="true" className="text-muted-foreground ml-2">
+            |
+          </div>
+          <DialogTrigger asChild>
             <Button
+              aria-label="Open trade settings"
               size="sm"
               variant="ghost"
-              className="h-6 pl-2 pr-0.5 hover:bg-transparent"
+              className="h-6 pr-0.5 pl-2 hover:bg-transparent"
               iconPosition="end"
               iconProps={iconProps}
               icon={SlidersVerticalIcon}
             />
-          </div>
-        )}
-      </DialogTrigger>
+          </DialogTrigger>
+        </div>
+      )}
       <DialogContent>
-        <DialogHeader className="mb-2 border-b border-border/50 pb-4">
+        <DialogHeader className="border-border/50 mb-2 border-b pb-4">
           <DialogTitle>Trade Settings</DialogTitle>
           <DialogDescription>
             Adjust to optimize your trade experience.

--- a/apps/org/src/lib/components/core/site-data-footer-secondary.tsx
+++ b/apps/org/src/lib/components/core/site-data-footer-secondary.tsx
@@ -101,10 +101,11 @@ export function FooterSettingsButton() {
 
   return (
     <button
+      aria-label="Open wallet settings"
       className="flex items-center gap-x-1 px-4 py-4 transition-opacity hover:opacity-80"
       onClick={() => setIsSlideOverOpen(true)}
     >
-      <CogIcon className="h-4 w-4" />
+      <CogIcon aria-hidden="true" className="h-4 w-4" />
     </button>
   )
 }

--- a/apps/org/src/lib/components/core/site-data-footer.tsx
+++ b/apps/org/src/lib/components/core/site-data-footer.tsx
@@ -13,7 +13,10 @@ import {
 
 export function SiteDataFooter() {
   return (
-    <div className="fixed right-0 bottom-0 left-0 z-60 hidden h-[40px] w-full border-t border-zinc-300 bg-zinc-50 md:block dark:border-zinc-700 dark:bg-zinc-900">
+    <footer
+      aria-label="Live market data and social links"
+      className="fixed right-0 bottom-0 left-0 z-60 hidden h-[40px] w-full border-t border-zinc-300 bg-zinc-50 md:block dark:border-zinc-700 dark:bg-zinc-900"
+    >
       <div className="flex h-full justify-between">
         <div className="flex text-left">
           <div className="flex items-center border-r border-zinc-300 px-4 dark:border-zinc-700">
@@ -55,27 +58,18 @@ export function SiteDataFooter() {
                 <ul className="flex items-center justify-center">
                   {[
                     {
-                      label: (
-                        <>
-                          <Telegram className="ml-auto h-4 w-4 fill-black dark:fill-zinc-400" />
-                        </>
-                      ),
+                      name: "Telegram",
+                      icon: Telegram,
                       href: SocialsEnum.telegram,
                     },
                     {
-                      label: (
-                        <>
-                          <Twitter className="ml-auto h-4 w-4 fill-black dark:fill-zinc-400" />
-                        </>
-                      ),
+                      name: "X",
+                      icon: Twitter,
                       href: SocialsEnum.twitter,
                     },
                     {
-                      label: (
-                        <>
-                          <Warpcast className="ml-auto h-4 w-4 fill-black dark:fill-zinc-400" />
-                        </>
-                      ),
+                      name: "Warpcast",
+                      icon: Warpcast,
                       href: SocialsEnum.warpcast,
                     },
                   ].map((item) => (
@@ -84,9 +78,13 @@ export function SiteDataFooter() {
                         href={item.href}
                         target="_blank"
                         rel="noopener noreferrer"
+                        aria-label={`X7 Finance on ${item.name}`}
                         className="text-muted-foreground hover:text-foreground text-sm"
                       >
-                        {item.label}
+                        <item.icon
+                          aria-hidden="true"
+                          className="ml-auto h-4 w-4 fill-black dark:fill-zinc-400"
+                        />
                       </LinkExternal>
                     </li>
                   ))}
@@ -131,6 +129,6 @@ export function SiteDataFooter() {
           </div>
         </div>
       </div>
-    </div>
+    </footer>
   )
 }

--- a/apps/org/src/lib/components/core/site-header.tsx
+++ b/apps/org/src/lib/components/core/site-header.tsx
@@ -13,8 +13,11 @@ export function SiteHeader({ className }: HTMLAttributes<HTMLElement>) {
     <header className={className}>
       <div className="flex flex-1 items-center justify-center">
         <div className="w-full">
-          <LinkInternal prefetch={true} href="/">
-            <X7LongLogo className="w-48 text-black dark:text-white" />
+          <LinkInternal prefetch={true} href="/" aria-label="X7 Finance home">
+            <X7LongLogo
+              aria-hidden="true"
+              className="w-48 text-black dark:text-white"
+            />
           </LinkInternal>
         </div>
       </div>
@@ -56,6 +59,7 @@ export function SiteHeader({ className }: HTMLAttributes<HTMLElement>) {
             <LinkInternal
               prefetch={true}
               href="/"
+              aria-label="Open Xchange"
               className={cn(
                 buttonVariants({
                   variant: "default",
@@ -63,7 +67,8 @@ export function SiteHeader({ className }: HTMLAttributes<HTMLElement>) {
                 "hidden py-1.5 lg:block"
               )}
             >
-              <Xchange className="w-24" />
+              <span className="sr-only">Open Xchange</span>
+              <Xchange aria-hidden="true" className="w-24" />
             </LinkInternal>
 
             <ClientMobileNavigation className="lg:hidden" />

--- a/apps/org/src/lib/components/utils/web3-connect-button.tsx
+++ b/apps/org/src/lib/components/utils/web3-connect-button.tsx
@@ -58,6 +58,7 @@ export function ConnectionComponent(
                   if (props["data-iscog"]) {
                     return (
                       <button
+                        aria-label="Connect wallet"
                         className="flex items-center gap-x-1 px-4 py-4 transition-opacity hover:opacity-80"
                         onClick={(e) => {
                           e.preventDefault()
@@ -65,7 +66,7 @@ export function ConnectionComponent(
                           openConnectModal()
                         }}
                       >
-                        <CogIcon className="h-4 w-4" />
+                        <CogIcon aria-hidden="true" className="h-4 w-4" />
                       </button>
                     )
                   }

--- a/apps/org/src/lib/providers/app.tsx
+++ b/apps/org/src/lib/providers/app.tsx
@@ -8,7 +8,7 @@ import {
   QueryClient,
   QueryClientProvider,
 } from "@tanstack/react-query"
-import { memo, Suspense, useMemo } from "react"
+import { memo, Suspense, useEffect, useMemo } from "react"
 
 import { Toaster } from "@x7/ui/sonner"
 import { SplashController } from "@x7/ui/splash"
@@ -31,6 +31,133 @@ interface ProvidersProps {
 
 const MemoizedTooltipProvider = memo(TooltipProvider)
 const MemoizedSplashController = memo(SplashController)
+
+function WalletAccessibility() {
+  useEffect(() => {
+    const shadowObservers: MutationObserver[] = []
+    const observedShadowRoots = new WeakSet<ShadowRoot>()
+    let syncModal = () => {}
+
+    const observeShadowRoot = (shadowRoot: ShadowRoot) => {
+      if (observedShadowRoots.has(shadowRoot)) {
+        return
+      }
+
+      observedShadowRoots.add(shadowRoot)
+      const observer = new MutationObserver(() => syncModal())
+      observer.observe(shadowRoot, {
+        attributes: true,
+        attributeFilter: ["class"],
+        childList: true,
+        subtree: true,
+      })
+      shadowObservers.push(observer)
+    }
+
+    const patchReownElement = (element: HTMLElement) => {
+      const root = element.getRootNode()
+      const shadowHost = root instanceof ShadowRoot ? root.host : null
+      const shadowHostTag = shadowHost?.tagName.toLowerCase()
+
+      if (
+        element.tagName === "WUI-CARD" &&
+        element.getAttribute("role") === "alertdialog"
+      ) {
+        element.setAttribute("aria-label", "Connect wallet")
+      }
+
+      if (element instanceof HTMLButtonElement) {
+        if (shadowHost?.getAttribute("data-testid") === "w3m-header-close") {
+          element.setAttribute("aria-label", "Close wallet dialog")
+        } else if (shadowHostTag === "wui-icon-link") {
+          element.setAttribute("aria-label", "Wallet help")
+        } else if (shadowHostTag === "wui-input-element") {
+          element.setAttribute("aria-label", "Clear wallet search")
+        } else if (shadowHostTag === "wui-certified-switch") {
+          element.setAttribute(
+            "aria-label",
+            "Show WalletConnect certified wallets only"
+          )
+        }
+      }
+
+      if (
+        element instanceof HTMLInputElement &&
+        element.type === "checkbox" &&
+        shadowHostTag === "wui-switch"
+      ) {
+        element.setAttribute("aria-hidden", "true")
+        element.disabled = true
+        element.tabIndex = -1
+
+        const hostRoot = shadowHost?.getRootNode()
+        const certifiedSwitch =
+          hostRoot instanceof ShadowRoot ? hostRoot.host : null
+        const toggle = certifiedSwitch?.shadowRoot?.querySelector("button")
+        toggle?.setAttribute("aria-pressed", String(element.checked))
+      }
+
+      if (element instanceof HTMLImageElement) {
+        element.alt = ""
+      }
+    }
+
+    const patchReownTree = (shadowRoot: ShadowRoot) => {
+      observeShadowRoot(shadowRoot)
+
+      shadowRoot.querySelectorAll<HTMLElement>("*").forEach((element) => {
+        patchReownElement(element)
+
+        if (element.shadowRoot) {
+          patchReownTree(element.shadowRoot)
+        }
+      })
+    }
+
+    syncModal = () => {
+      document
+        .querySelectorAll<HTMLElement>(
+          '[data-testid^="rk-wallet-option-"] [role="img"]'
+        )
+        .forEach((icon) => icon.setAttribute("aria-hidden", "true"))
+
+      const walletConnectShadowRoot =
+        document.querySelector("wcm-modal")?.shadowRoot
+
+      if (walletConnectShadowRoot) {
+        observeShadowRoot(walletConnectShadowRoot)
+        const modal =
+          walletConnectShadowRoot.querySelector<HTMLElement>("#wcm-modal")
+
+        if (modal) {
+          const isOpen = modal.classList.contains("wcm-active")
+
+          modal.setAttribute("aria-label", "Connect wallet")
+          modal.setAttribute("aria-hidden", isOpen ? "false" : "true")
+          modal.inert = !isOpen
+        }
+      }
+
+      const reownShadowRoot = document.querySelector("w3m-modal")?.shadowRoot
+
+      if (reownShadowRoot) {
+        patchReownTree(reownShadowRoot)
+      }
+    }
+
+    syncModal()
+
+    const documentObserver = new MutationObserver(() => syncModal())
+    documentObserver.observe(document.body, { childList: true, subtree: true })
+
+    return () => {
+      documentObserver.disconnect()
+      shadowObservers.forEach((observer) => observer.disconnect())
+    }
+  }, [])
+
+  return null
+}
 
 export function AppProviders(props: ProvidersProps) {
   const queryClient = useMemo(
@@ -56,6 +183,7 @@ export function AppProviders(props: ProvidersProps) {
     <QueryClientProvider client={queryClient}>
       <Suspense>
         <Web3Provider initialState={props.initialState}>
+          <WalletAccessibility />
           <div className="xl:max-w-none">
             <div className="relative z-0">
               <TransactionStoreProvider>

--- a/apps/org/src/lib/providers/web3.tsx
+++ b/apps/org/src/lib/providers/web3.tsx
@@ -201,16 +201,25 @@ export function Web3Provider(props: Web3ProvidersProps) {
     [setTransports]
   )
 
-  const theme = useMemo(
-    () =>
-      darkTheme({
-        ...darkTheme.accentColors.purple,
-        accentColor: "#17803d",
-        borderRadius: "medium",
-        fontStack: "system",
-      }),
-    []
-  )
+  const theme = useMemo(() => {
+    const defaultTheme = darkTheme({
+      ...darkTheme.accentColors.purple,
+      accentColor: "#34d399",
+      borderRadius: "medium",
+      fontStack: "system",
+    })
+
+    return {
+      ...defaultTheme,
+      colors: {
+        ...defaultTheme.colors,
+        accentColorForeground: "#052e16",
+        modalText: "#ffffff",
+        modalTextDim: "#a1a1aa",
+        modalTextSecondary: "#d4d4d8",
+      },
+    }
+  }, [])
 
   const contextValue = useMemo(
     () => ({ wagmiConfig, transports, updateTransports }),

--- a/packages/ui/src/contract-copy.tsx
+++ b/packages/ui/src/contract-copy.tsx
@@ -15,11 +15,11 @@ export function ContractCopy(props: { contract: string; chainId?: ChainId }) {
 
   return (
     <span className="flex items-center">
-      <span className="mr-1 text-2xs text-[11px] font-bold uppercase text-muted-foreground/30">
+      <span className="text-2xs mr-1 text-[11px] font-bold text-zinc-600 uppercase dark:text-zinc-400">
         {displayName}
       </span>
       <span className="flex items-center">
-        <span className="text-xs leading-5 text-muted-foreground">
+        <span className="text-muted-foreground text-xs leading-5">
           <span className="sm:hidden">{formattedAddress}</span>
           <span className="hidden sm:inline">{contract}</span>
         </span>

--- a/packages/ui/src/currency/currency-icon.tsx
+++ b/packages/ui/src/currency/currency-icon.tsx
@@ -30,6 +30,24 @@ function hashStringToColor(str: string) {
   )}${`0${b.toString(16)}`.substr(-2)}`
 }
 
+function getContrastTextColor(backgroundColor: string) {
+  const channels = [1, 3, 5].map((offset) => {
+    const channel = Number.parseInt(
+      backgroundColor.slice(offset, offset + 2),
+      16
+    )
+    const normalized = channel / 255
+
+    return normalized <= 0.04045
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4
+  })
+  const [red = 0, green = 0, blue = 0] = channels
+  const luminance = 0.2126 * red + 0.7152 * green + 0.0722 * blue
+
+  return luminance > 0.179 ? "#000000" : "#ffffff"
+}
+
 export interface CurrencyIconProps extends Omit<ImageProps, "src" | "alt"> {
   currency: Currency
   disableLink?: boolean
@@ -69,8 +87,8 @@ export const CurrencyIcon = ({
   }
 
   // Convert width/height to numbers with default value
-  const widthPx = typeof width === "number" ? width : Number(width || 20)
-  const heightPx = typeof height === "number" ? height : Number(height || 20)
+  const widthPx = typeof width === "number" ? width : Number(width ?? 20)
+  const heightPx = typeof height === "number" ? height : Number(height ?? 20)
 
   const fallbackElement = (
     <div
@@ -82,7 +100,7 @@ export const CurrencyIcon = ({
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        color: "white",
+        color: getContrastTextColor(fallbackColor),
         fontSize: `${Math.max(12, widthPx / 1.8)}px`,
         fontWeight: "bold",
         overflow: "hidden",

--- a/packages/ui/src/pagination.tsx
+++ b/packages/ui/src/pagination.tsx
@@ -42,7 +42,7 @@ function PaginationItem({ ...props }: React.ComponentProps<"li">) {
 type PaginationLinkProps = {
   isActive?: boolean
 } & Pick<React.ComponentProps<typeof Button>, "size"> &
-  React.ComponentProps<"a">
+  React.ComponentProps<"button">
 
 function PaginationLink({
   className,
@@ -51,7 +51,8 @@ function PaginationLink({
   ...props
 }: PaginationLinkProps) {
   return (
-    <a
+    <button
+      type="button"
       aria-current={isActive ? "page" : undefined}
       data-slot="pagination-link"
       data-active={isActive}

--- a/packages/ui/src/static-table.tsx
+++ b/packages/ui/src/static-table.tsx
@@ -32,7 +32,7 @@ export const StaticTable: FC<StaticTableProps> = ({ data, columns }) => {
               {...(column.width && index === 0 ? { width: column.width } : {})}
               className={cn(
                 column.responsive ? "hidden lg:table-cell" : "",
-                "border-b border-t border-zinc-200 px-3 py-3 text-left text-xs font-semibold uppercase text-zinc-500 last:pr-8 last:text-right dark:border-zinc-800 sm:first:pl-6"
+                "border-t border-b border-zinc-200 px-3 py-3 text-left text-xs font-semibold text-zinc-600 uppercase last:pr-8 last:text-right sm:first:pl-6 dark:border-zinc-800 dark:text-zinc-400"
               )}
             >
               <>


### PR DESCRIPTION
## Summary
- resolve accessibility violations across the marketing, docs, dashboard, and Xchange routes
- add accessible landmarks, dialog/menu titles, control and social-link names, form/table semantics, and keyboard focus indicators
- improve text and generated token-icon contrast
- synchronize RainbowKit/Reown wallet modal accessibility state, names, and decorative content
- allow configured RPC origins, viem defaults for every supported chain, and established public fallback providers in the Content Security Policy

## Validation
- `bun run checks`
- verified the generated CSP includes supported-chain defaults, configured RPC origins without leaking URL paths/query keys, and public provider fallbacks
- Agent Browser + axe desktop audit: 0 violations on `/`, `/about`, `/products`, `/docs`, `/dashboard`, `/swap`, `/liquidity`, `/lending`, `/create`, `/fund`, and `/vote`
- Agent Browser + axe mobile audit: 0 violations on `/`, `/about`, `/docs`, `/swap`, `/create`, and `/dashboard`
- Interactive-state audits: 0 violations with the Xchange drawer, marketing navigation sheet, RainbowKit wallet dialog, and Reown wallet dialog open

The branch was rebased onto the latest `origin/main` immediately before push.
