### PR TITLE
fix: restore disconnected swap quotes

### DIFF
--- a/apps/org/src/app/(xchange)/_actions/execute-route.tsx
+++ b/apps/org/src/app/(xchange)/_actions/execute-route.tsx
@@ -1,10 +1,11 @@
 /* oxlint-disable @typescript-eslint/no-unnecessary-condition */
 import type { Config } from "@wagmi/core"
 import { getWalletClient } from "@wagmi/core"
+import type { Address } from "viem"
 import { isAddress, isHex } from "viem"
 
 import type { SwapRoute } from "@x7/smart-order-router"
-import type { CurrencyAmount, Native, Token } from "@x7/utils"
+import type { ChainId, CurrencyAmount, Native, Token } from "@x7/utils"
 
 import { getTokenTransferApproval } from "./get-token-transfer-approval"
 
@@ -12,9 +13,22 @@ export async function executeRoute(routeInfo: {
   token0: Token | Native
   swapAmount: CurrencyAmount<Token | Native>
   route: SwapRoute | undefined
+  expectedRecipient: Address | undefined
+  currentQuoteKey: string
+  routeQuoteKey: string | undefined
+  expectedChainId: ChainId
   config: Config
 }): Promise<`0x${string}`> {
-  const { token0, swapAmount, route, config } = routeInfo
+  const {
+    token0,
+    swapAmount,
+    route,
+    expectedRecipient,
+    currentQuoteKey,
+    routeQuoteKey,
+    expectedChainId,
+    config,
+  } = routeInfo
   const walletClient = await getWalletClient(config)
 
   if (!walletClient) {
@@ -23,6 +37,18 @@ export async function executeRoute(routeInfo: {
 
   if (!walletClient.account.address) {
     throw new Error("Could not get address")
+  }
+
+  if (!expectedRecipient) {
+    throw new Error("No recipient address available")
+  }
+
+  if (!routeQuoteKey || routeQuoteKey !== currentQuoteKey) {
+    throw new Error("Quote no longer matches the current swap")
+  }
+
+  if (walletClient.chain?.id !== expectedChainId) {
+    throw new Error("Quote chain no longer matches the connected wallet")
   }
 
   // Validate router address and calldata before proceeding

--- a/apps/org/src/app/(xchange)/_actions/generate-route.tsx
+++ b/apps/org/src/app/(xchange)/_actions/generate-route.tsx
@@ -3,13 +3,14 @@
 "use client"
 
 import type { Config } from "@wagmi/core"
-import { getPublicClient, getWalletClient } from "@wagmi/core"
+import { getPublicClient } from "@wagmi/core"
 
 import type { AlphaRouter, SwapRoute } from "@x7/smart-order-router"
 import { SwapType, WRAPPED_NATIVE_CURRENCY } from "@x7/smart-order-router"
-import { LogCodes, Percent, TradeType } from "@x7/utils"
+import { Percent, TradeType } from "@x7/utils"
 import type { SwapState } from "~/lib/stores/swap"
-import { log } from "~/lib/utils/log"
+
+const QUOTE_RECIPIENT_ADDRESS = "0x000000000000000000000000000000000000dEaD"
 
 export const generateRoute = async (
   swapState: SwapState,
@@ -20,19 +21,6 @@ export const generateRoute = async (
     state: { token1, token0, swapAmount, recipient },
     mutate: { clearPossibleRoutes },
   } = swapState
-  const publicClient = getPublicClient(config)
-  let walletClient
-
-  try {
-    walletClient = await getWalletClient(config)
-  } catch (error) {
-    log.error(LogCodes.FAIL, "No wallet connected", { error })
-  }
-
-  if (!walletClient && !publicClient) {
-    throw new Error("No Clients Detected")
-  }
-
   if (!token0 || !token1) {
     throw new Error("No tokens selected!")
   }
@@ -41,12 +29,16 @@ export const generateRoute = async (
     throw new Error("No swap amount specified!")
   }
 
-  const [address] = (await walletClient?.requestAddresses()) ?? []
-  const recipientAddress = recipient ?? address
-
-  if (!recipientAddress) {
-    throw new Error("No recipient address available!")
+  const publicClient = getPublicClient(config, { chainId: token0.chainId })
+  if (!publicClient) {
+    throw new Error("No public client detected")
   }
+
+  const connectedRecipientAddress = recipient
+  const recipientAddress = connectedRecipientAddress ?? QUOTE_RECIPIENT_ADDRESS
+  const simulation = connectedRecipientAddress
+    ? { simulate: { fromAddress: connectedRecipientAddress } }
+    : {}
 
   clearPossibleRoutes()
   //router.abortCurrentRoute();
@@ -65,9 +57,7 @@ export const generateRoute = async (
       slippageTolerance: swapState.state.slippage ?? new Percent(50, 10_000),
       deadline: Math.floor(+new Date() / 1000 + 60 * 20),
       type: SwapType.SWAP_ROUTER_02,
-      simulate: {
-        fromAddress: recipientAddress,
-      },
+      ...simulation,
     })
   }
 
@@ -80,9 +70,7 @@ export const generateRoute = async (
       slippageTolerance: swapState.state.slippage ?? new Percent(50, 10_000),
       deadline: Math.floor(+new Date() / 1000 + 60 * 20),
       type: SwapType.SWAP_ROUTER_02,
-      simulate: {
-        fromAddress: recipientAddress,
-      },
+      ...simulation,
       saveRoutes: true,
     },
     {

--- a/apps/org/src/app/(xchange)/_components/swap/(hooks)/use-swap-form-logic.tsx
+++ b/apps/org/src/app/(xchange)/_components/swap/(hooks)/use-swap-form-logic.tsx
@@ -38,11 +38,18 @@ export function useSwapFormLogic(
     mutate: { trackTransaction },
   } = useTransactionStore()
   const {
-    state: { swapAmount, token0Approval },
+    state: {
+      swapAmount,
+      token0Approval,
+      recipient,
+      routeQuoteKey,
+      currentQuoteKey,
+      chainId,
+    },
     mutate: { setToken0, setToken1, setSwapAmount },
     loaders: { isQuoteLoading },
   } = useSwapState()
-  const chainId = useChainId() as ChainId
+  const walletChainId = useChainId() as ChainId
   const { address } = useAccount()
 
   const [refetchCount, setRefetchCount] = useState(0)
@@ -66,6 +73,10 @@ export function useSwapFormLogic(
     !!token0 &&
     !!token1 &&
     !!route &&
+    !!recipient &&
+    !!routeQuoteKey &&
+    routeQuoteKey === currentQuoteKey &&
+    walletChainId === chainId &&
     !isQuoteLoading &&
     (!token0.isNative
       ? token0Approval.approval !== ApprovalState.NOT_APPROVED
@@ -182,6 +193,10 @@ export function useSwapFormLogic(
           token0,
           swapAmount: swapAmount!,
           route,
+          expectedRecipient: recipient,
+          currentQuoteKey,
+          routeQuoteKey,
+          expectedChainId: chainId,
           config,
         })
       }
@@ -192,7 +207,19 @@ export function useSwapFormLogic(
       toast.error(errorMessage)
       setIsPending(false)
     }
-  }, [token0, swapAmount, route, config, onSettled, isWrap, isUnwrap])
+  }, [
+    token0,
+    swapAmount,
+    route,
+    recipient,
+    currentQuoteKey,
+    routeQuoteKey,
+    chainId,
+    config,
+    onSettled,
+    isWrap,
+    isUnwrap,
+  ])
 
   return {
     refetchCount,

--- a/apps/org/src/lib/providers/router.tsx
+++ b/apps/org/src/lib/providers/router.tsx
@@ -5,6 +5,7 @@
 "use client"
 
 import { getPublicClient } from "@wagmi/core"
+import { useSearchParams } from "next/navigation"
 import type { FC } from "react"
 import React, {
   createContext,
@@ -13,7 +14,7 @@ import React, {
   useMemo,
   useState,
 } from "react"
-import { useAccount } from "wagmi"
+import { useAccount, useChainId } from "wagmi"
 
 import type { BestSwapRoute, RouteWithValidQuote } from "@x7/smart-order-router"
 import { AlphaRouter } from "@x7/smart-order-router"
@@ -29,6 +30,7 @@ export interface AlphaRouterState {
     bestRoute: BestSwapRoute | undefined
     secondaryRoute: BestSwapRoute | undefined
     enabledImplementations: Implementation[]
+    activeChainId: ChainId
     isChainIdSettled: boolean
     debouncedChainId: number | undefined
   }
@@ -53,12 +55,23 @@ export const AlphaRouterProvider: FC<AlphaRouterProviderProps> = ({
   children,
 }) => {
   const { wagmiConfig } = useWeb3Config()
+  const searchParams = useSearchParams()
+  const { chainId: connectedChainId } = useAccount()
+  const configuredChainId = useChainId()
+  const requestedChainId = Number(searchParams.get("chainId"))
+  const isConfiguredChain = (chainId: number | undefined): chainId is ChainId =>
+    chainId !== undefined &&
+    wagmiConfig.chains.some((chain) => chain.id === chainId)
+  const activeChainId = isConfiguredChain(connectedChainId)
+    ? connectedChainId
+    : isConfiguredChain(requestedChainId)
+      ? requestedChainId
+      : configuredChainId
   const publicClient = useMemo(
-    () => getPublicClient(wagmiConfig),
-    [wagmiConfig]
+    () => getPublicClient(wagmiConfig, { chainId: activeChainId }),
+    [activeChainId, wagmiConfig]
   )
-  const { chainId: realChain } = useAccount()
-  const debouncedChainId = useDebounce(realChain, 500)
+  const debouncedChainId = useDebounce(activeChainId, 500)
   const [isChainIdSettled, setIsChainIdSettled] = useState(false)
   const [possibleRoutes, setPossibleRoutes] = useState<RouteWithValidQuote[]>(
     []
@@ -93,20 +106,19 @@ export const AlphaRouterProvider: FC<AlphaRouterProviderProps> = ({
   }, [debouncedChainId])
 
   const router: AlphaRouter | null = useMemo(() => {
-    if (realChain) {
-      const _router = new AlphaRouter({
-        chainId: realChain as ChainId,
-        // @ts-expect-error I know man
-        provider: publicClient,
-        addPossibleRoutes,
-        setBestRoute,
-        setSecondaryRoute,
-        enabledImplementations,
-      })
-      return _router
+    if (!publicClient) {
+      return null
     }
-    return null
-  }, [realChain, _enabledImplementations])
+
+    return new AlphaRouter({
+      chainId: activeChainId as ChainId,
+      provider: publicClient,
+      addPossibleRoutes,
+      setBestRoute,
+      setSecondaryRoute,
+      enabledImplementations,
+    })
+  }, [activeChainId, enabledImplementations, publicClient])
 
   const builtState: AlphaRouterState = useMemo(
     () => ({
@@ -116,6 +128,7 @@ export const AlphaRouterProvider: FC<AlphaRouterProviderProps> = ({
         secondaryRoute,
         possibleRoutes,
         enabledImplementations,
+        activeChainId: activeChainId as ChainId,
         isChainIdSettled,
         debouncedChainId,
       },
@@ -135,6 +148,7 @@ export const AlphaRouterProvider: FC<AlphaRouterProviderProps> = ({
       secondaryRoute,
       possibleRoutes,
       enabledImplementations,
+      activeChainId,
       isChainIdSettled,
       debouncedChainId,
       addPossibleRoutes,

--- a/apps/org/src/lib/stores/swap/index.ts
+++ b/apps/org/src/lib/stores/swap/index.ts
@@ -13,7 +13,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef } from "react"
 import type { Address } from "viem"
 import { isAddress } from "viem"
-import { useAccount, useChainId, useConfig } from "wagmi"
+import { useAccount, useConfig } from "wagmi"
 
 import { X7ContractsEnum } from "@x7/sdk"
 import type { RouteWithValidQuote, SwapRoute } from "@x7/smart-order-router"
@@ -29,7 +29,6 @@ import {
   CurrencyAmount,
   LogCodes,
   Native,
-  pDebounce,
   safeParseUnits,
   Percent,
   TradeType,
@@ -54,14 +53,47 @@ export type * from "./types"
 
 const getQuoteCurrency = (chainId: ChainId) => X7ContractsEnum.X7R(chainId)
 
+function getCurrencyQuoteKey(currency: Token | Native | undefined): string {
+  if (!currency) {
+    return "UNRESOLVED"
+  }
+
+  return currency.isNative ? "NATIVE" : currency.address.toLowerCase()
+}
+
+function getQuoteKey({
+  chainId,
+  token0,
+  token1,
+  swapAmount,
+  recipient,
+}: {
+  chainId: ChainId
+  token0: Token | Native | undefined
+  token1: Token | Native | undefined
+  swapAmount: string
+  recipient: Address | undefined
+}): string {
+  return [
+    chainId,
+    getCurrencyQuoteKey(token0),
+    getCurrencyQuoteKey(token1),
+    swapAmount.trim(),
+    recipient?.toLowerCase() ?? "QUOTE_ONLY",
+  ].join(":")
+}
+
 export function useSwapState(): SwapState {
-  const initialChainId = useChainId() as ChainId
   const { address } = useAccount()
   const { wagmiConfig } = useWeb3Config()
   const config = useConfig()
 
   const {
-    state: { router, enabledImplementations: routerEnabledImplementations },
+    state: {
+      router,
+      enabledImplementations: routerEnabledImplementations,
+      activeChainId,
+    },
     mutate: {
       addPossibleRoutes: routerAddPossibleRoutes,
       clearPossibleRoutes: routerClearPossibleRoutes,
@@ -92,6 +124,7 @@ export function useSwapState(): SwapState {
     (s) => s.setEnabledImplementations
   )
   const route = useSwapQuoteStore((s) => s.route)
+  const routeQuoteKey = useSwapQuoteStore((s) => s.routeQuoteKey)
   const possibleRoutes = useSwapQuoteStore((s) => s.possibleRoutes)
   const bestRoute = useSwapQuoteStore((s) => s.bestRoute)
   const secondaryRoute = useSwapQuoteStore((s) => s.secondaryRoute)
@@ -109,9 +142,7 @@ export function useSwapState(): SwapState {
   // Get the searchParams and complete with defaults
   const defaultedParams = useMemo(() => {
     const params = new URLSearchParams(searchParams)
-    if (!params.has("chainId")) {
-      params.set("chainId", (initialChainId || ChainId.BASE).toString())
-    }
+    params.set("chainId", activeChainId.toString())
 
     if (!params.has("token0")) {
       params.set("token0", "NATIVE")
@@ -124,9 +155,9 @@ export function useSwapState(): SwapState {
       )
     }
     return params
-  }, [initialChainId, searchParams])
+  }, [activeChainId, searchParams])
 
-  const chainId = Number(defaultedParams.get("chainId")) as ChainId
+  const chainId = activeChainId
 
   // Create query string helper
   const createQueryString = useCallback(
@@ -187,6 +218,17 @@ export function useSwapState(): SwapState {
     defaultedParams.get("token1") === "NATIVE"
       ? Native.onChain(chainId)
       : token1FromCache
+
+  const currentQuoteKey = getQuoteKey({
+    chainId,
+    token0: _token0,
+    token1: _token1,
+    swapAmount: swapAmountString,
+    recipient,
+  })
+  const currentQuoteKeyRef = useRef(currentQuoteKey)
+  const alternativeRequestIdRef = useRef(0)
+  currentQuoteKeyRef.current = currentQuoteKey
 
   const intendedRouterAddress: `0x${string}` =
     route?.methodParameters?.to ?? `0x`
@@ -369,6 +411,9 @@ export function useSwapState(): SwapState {
 
   const tryAlternativeRoute = useCallback(
     async (routeToUse: RouteWithValidQuote): Promise<SwapRoute | null> => {
+      const quoteKey = currentQuoteKey
+      const requestId = ++alternativeRequestIdRef.current
+
       if (!router) {
         throw new Error("No AlphaRouter instance setup")
       }
@@ -394,47 +439,32 @@ export function useSwapState(): SwapState {
           },
         }
       )
+      if (
+        requestId !== alternativeRequestIdRef.current ||
+        quoteKey !== currentQuoteKeyRef.current
+      ) {
+        return null
+      }
+
       if (newRoute) {
-        setRoute(newRoute)
+        setRoute(newRoute, quoteKey)
       }
 
       return newRoute
     },
-    [router, swapAmountString, _token0, recipient, address, slippage, setRoute]
+    [
+      router,
+      swapAmountString,
+      _token0,
+      recipient,
+      address,
+      slippage,
+      setRoute,
+      currentQuoteKey,
+    ]
   )
 
-  // Debounced route generation
-  const throttleRouteGenRef = useRef(
-    pDebounce(async (param: SwapState) => {
-      if (!param.state.token0 || !param.state.token1 || !router) {
-        return
-      }
-
-      router.abortCurrentRoute()
-      await generateRoute(param, wagmiConfig, router)
-        .then((_route) => {
-          setIsQuoteLoading(false)
-
-          if (_route) {
-            setSwapError(undefined)
-            setRoute(_route)
-          } else {
-            setSwapError({
-              message: `No quotes found, Routers used: ${enabledImplementations.join(",").toLowerCase()}`,
-            })
-          }
-        })
-        .catch((error: Error) => {
-          log.error(LogCodes.FAIL, "Promise executed with error", `${error}`)
-          routerSetPossibleRoutes([])
-          setRoute(undefined)
-          routerSetBestRoute(undefined)
-          routerSetSecondaryRoute(undefined)
-          setIsQuoteLoading(false)
-          setSwapError({ message: error.message })
-        })
-    }, 250)
-  )
+  const quoteRequestIdRef = useRef(0)
 
   const builtState: SwapState = useMemo(
     () => ({
@@ -444,6 +474,7 @@ export function useSwapState(): SwapState {
         swapAmountString,
         swapAmount: tryParseAmount(swapAmountString, _token0),
         route,
+        routeQuoteKey,
         recipient,
         slippage,
         swapError,
@@ -453,6 +484,7 @@ export function useSwapState(): SwapState {
         secondaryRoute,
         enabledImplementations,
         chainId,
+        currentQuoteKey,
         token0Address: (defaultedParams.get("token0") ?? "0x") as Address,
         token1Address: (defaultedParams.get("token1") ?? "0x") as Address,
       },
@@ -479,6 +511,7 @@ export function useSwapState(): SwapState {
       _token1,
       swapAmountString,
       route,
+      routeQuoteKey,
       recipient,
       slippage,
       swapError,
@@ -488,6 +521,7 @@ export function useSwapState(): SwapState {
       secondaryRoute,
       enabledImplementations,
       chainId,
+      currentQuoteKey,
       defaultedParams,
       switchTokens,
       setToken0,
@@ -507,18 +541,63 @@ export function useSwapState(): SwapState {
 
   // Route generation effect
   useEffect(() => {
+    const requestId = ++quoteRequestIdRef.current
+    alternativeRequestIdRef.current += 1
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const isCurrentRequest = () => quoteRequestIdRef.current === requestId
+
+    router?.abortCurrentRoute()
     routerSetPossibleRoutes([])
     routerSetBestRoute(undefined)
     routerSetSecondaryRoute(undefined)
     setRoute(undefined)
     setSwapError(undefined)
+    setIsQuoteLoading(false)
 
-    if (_token0 && _token1 && parseFloat(`${swapAmountString}`) > 0) {
+    if (router && _token0 && _token1 && parseFloat(`${swapAmountString}`) > 0) {
       setIsQuoteLoading(true)
-      void throttleRouteGenRef.current(builtState)
+      timeout = setTimeout(() => {
+        void generateRoute(builtState, wagmiConfig, router)
+          .then((_route) => {
+            if (!isCurrentRequest()) {
+              return
+            }
+
+            setIsQuoteLoading(false)
+            if (_route) {
+              setSwapError(undefined)
+              setRoute(_route, currentQuoteKey)
+            } else {
+              setSwapError({
+                message: `No quotes found, Routers used: ${enabledImplementations.join(",").toLowerCase()}`,
+              })
+            }
+          })
+          .catch((error: Error) => {
+            if (!isCurrentRequest()) {
+              return
+            }
+
+            log.error(LogCodes.FAIL, "Promise executed with error", `${error}`)
+            routerSetPossibleRoutes([])
+            setRoute(undefined)
+            routerSetBestRoute(undefined)
+            routerSetSecondaryRoute(undefined)
+            setIsQuoteLoading(false)
+            setSwapError({ message: error.message })
+          })
+      }, 250)
+    }
+
+    return () => {
+      clearTimeout(timeout)
+      if (isCurrentRequest()) {
+        quoteRequestIdRef.current += 1
+      }
+      router?.abortCurrentRoute()
     }
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [chainId, router, address, _token0, _token1, swapAmountString])
+  }, [chainId, router, currentQuoteKey, slippage, enabledImplementations])
 
   return builtState
 }

--- a/apps/org/src/lib/stores/swap/quote.ts
+++ b/apps/org/src/lib/stores/swap/quote.ts
@@ -13,6 +13,7 @@ interface SwapQuoteStore extends SwapQuoteState, SwapQuoteActions {}
 
 export const useSwapQuoteStore = create<SwapQuoteStore>((set) => ({
   route: undefined,
+  routeQuoteKey: undefined,
   possibleRoutes: [],
   bestRoute: undefined,
   secondaryRoute: undefined,
@@ -20,7 +21,8 @@ export const useSwapQuoteStore = create<SwapQuoteStore>((set) => ({
   isQuoteLoading: false,
   swapError: undefined,
 
-  setRoute: (route: SwapRoute | undefined) => set({ route }),
+  setRoute: (route: SwapRoute | undefined, routeQuoteKey) =>
+    set({ route, routeQuoteKey: route ? routeQuoteKey : undefined }),
 
   addPossibleRoutes: (routes: RouteWithValidQuote[]) =>
     set((state) => ({

--- a/apps/org/src/lib/stores/swap/types.ts
+++ b/apps/org/src/lib/stores/swap/types.ts
@@ -46,6 +46,7 @@ export interface SwapAmountActions {
 
 export interface SwapQuoteState {
   route: SwapRoute | undefined
+  routeQuoteKey: string | undefined
   possibleRoutes: RouteWithValidQuote[]
   bestRoute: BestSwapRoute | undefined
   secondaryRoute: BestSwapRoute | undefined
@@ -55,7 +56,7 @@ export interface SwapQuoteState {
 }
 
 export interface SwapQuoteActions {
-  setRoute: (route: SwapRoute | undefined) => void
+  setRoute: (route: SwapRoute | undefined, quoteKey?: string) => void
   addPossibleRoutes: (routes: RouteWithValidQuote[]) => void
   setPossibleRoutes: (routes: RouteWithValidQuote[]) => void
   setBestRoute: (route: BestSwapRoute | undefined) => void
@@ -88,6 +89,7 @@ export interface SwapState {
     swapAmountString: string
     swapAmount: CurrencyAmount<Token | Native> | undefined
     route: SwapRoute | undefined
+    routeQuoteKey: string | undefined
     slippage: Percent
     swapError: { message: string } | undefined
     token0Approval: TokenApprovals
@@ -96,6 +98,7 @@ export interface SwapState {
     secondaryRoute: BestSwapRoute | undefined
     enabledImplementations: Implementation[]
     chainId: ChainId
+    currentQuoteKey: string
   }
   mutate: {
     setToken0: (token0: Token | Native | string) => void

--- a/packages/e2e/tests/a11y.spec.ts
+++ b/packages/e2e/tests/a11y.spec.ts
@@ -15,8 +15,8 @@ test.describe("accessibility: icon controls are labelled", () => {
     await page.setViewportSize({ width: 390, height: 844 })
     await page.goto("/swap", { waitUntil: "domcontentloaded" })
     await page.waitForTimeout(2000)
-    await expect(page.getByRole("button", { name: "Open menu" })).toBeVisible({
-      timeout: 15000,
-    })
+    await expect(
+      page.getByRole("button", { name: "Open navigation menu" })
+    ).toBeVisible({ timeout: 15000 })
   })
 })

--- a/packages/e2e/tests/navigation.spec.ts
+++ b/packages/e2e/tests/navigation.spec.ts
@@ -21,7 +21,7 @@ test.describe("navigation", () => {
     await page.goto("/swap", { waitUntil: "domcontentloaded" })
     await page.waitForTimeout(2000)
 
-    const open = page.getByRole("button", { name: "Open menu" })
+    const open = page.getByRole("button", { name: "Open navigation menu" })
     await expect(open).toBeVisible({ timeout: 15000 })
     await open.click()
 

--- a/packages/smart-order-router/src/routers/alpha-router/alpha-router.ts
+++ b/packages/smart-order-router/src/routers/alpha-router/alpha-router.ts
@@ -911,7 +911,7 @@ export class AlphaRouter
     swapConfig?: SwapOptions,
     partialRoutingConfig: Partial<AlphaRouterConfig> = {}
   ): Promise<SwapRoute | null> {
-    // this.abortCurrentRoute();
+    this.abortCurrentRoute()
     this.currentAbortController = new AbortController()
     const signal = this.currentAbortController.signal
 
@@ -1105,7 +1105,8 @@ export class AlphaRouter
         v3GasModel,
         mixedRouteGasModel,
         gasPriceWei,
-        swapConfig
+        swapConfig,
+        signal
       )
     }
 
@@ -1123,7 +1124,8 @@ export class AlphaRouter
         v3GasModel,
         mixedRouteGasModel,
         gasPriceWei,
-        swapConfig
+        swapConfig,
+        signal
       )
     }
 
@@ -1196,8 +1198,14 @@ export class AlphaRouter
       }
     }
 
-    if (!!swapRouteRaw && this.setBestRoute && swapConfig?.saveRoutes)
+    if (
+      !!swapRouteRaw &&
+      this.setBestRoute &&
+      swapConfig?.saveRoutes &&
+      (!signal.aborted || swapConfig.ignoreAborts)
+    ) {
       this.setBestRoute(swapRouteRaw)
+    }
 
     if (
       cacheMode === CacheMode.Tapcompare &&
@@ -1460,6 +1468,9 @@ export class AlphaRouter
     tradeType: TradeType,
     swapConfig?: SwapOptions
   ): Promise<SwapRoute | null> {
+    this.abortCurrentRoute()
+    this.currentAbortController = new AbortController()
+    const signal = this.currentAbortController.signal
     const blockNumber = await this.getBlockNumberPromise()
 
     // Build Trade object that represents the optimal swap.
@@ -1528,8 +1539,13 @@ export class AlphaRouter
       routes: [swapRouteRaw],
     }
 
-    if (!!newBestRoute && this.setSecondaryRoute)
+    if (
+      !!newBestRoute &&
+      this.setSecondaryRoute &&
+      (!signal.aborted || swapConfig?.ignoreAborts)
+    ) {
       this.setSecondaryRoute(newBestRoute)
+    }
 
     const swapRoute: SwapRoute = {
       quote: correctedQuote,
@@ -1560,7 +1576,8 @@ export class AlphaRouter
     v3GasModel: IGasModel<V3RouteWithValidQuote>,
     mixedRouteGasModel: IGasModel<MixedRouteWithValidQuote>,
     gasPriceWei: bigint,
-    swapConfig?: SwapOptions
+    swapConfig: SwapOptions | undefined,
+    signal: AbortSignal
   ): Promise<BestSwapRoute | null> {
     log.info(LogCodes.CACHE_HIT, "Routing across CachedRoute", {
       protocols: cachedRoutes.protocolsCovered,
@@ -1723,7 +1740,11 @@ export class AlphaRouter
       (quoteResult) => quoteResult.routesWithValidQuotes
     )
 
-    if (this.addPossibleRoutes && swapConfig?.saveRoutes) {
+    if (
+      this.addPossibleRoutes &&
+      swapConfig?.saveRoutes &&
+      (!signal.aborted || swapConfig.ignoreAborts)
+    ) {
       this.addPossibleRoutes(
         allRoutesWithValidQuotes.filter((q) => q.percent === 100)
       )
@@ -1755,7 +1776,8 @@ export class AlphaRouter
     v3GasModel: IGasModel<V3RouteWithValidQuote>,
     mixedRouteGasModel: IGasModel<MixedRouteWithValidQuote>,
     gasPriceWei: bigint,
-    swapConfig?: SwapOptions
+    swapConfig: SwapOptions | undefined,
+    signal: AbortSignal
   ): Promise<BestSwapRoute | null> {
     // Generate our distribution of amounts, i.e. fractions of the input amount.
     // We will get quotes for fractions of the input amount for different routes, then
@@ -2035,7 +2057,11 @@ export class AlphaRouter
       return null
     }
 
-    if (this.addPossibleRoutes && swapConfig?.saveRoutes) {
+    if (
+      this.addPossibleRoutes &&
+      swapConfig?.saveRoutes &&
+      (!signal.aborted || swapConfig.ignoreAborts)
+    ) {
       this.addPossibleRoutes(validRoutes.filter((q) => q.percent === 100))
     }
 


### PR DESCRIPTION
## Summary
- initialize the swap router from a validated connected, URL-requested, or default chain instead of requiring a connected wallet
- allow quote-only routing without an account while omitting wallet simulation
- bind executable routes to the current chain, tokens, amount, and recipient
- cancel and reject stale primary/alternative quote results and suppress aborted router callbacks
- revalidate quote identity and wallet chain immediately before execution

## Root cause
The router provider only created an `AlphaRouter` when `useAccount()` returned a connected chain, and route generation rejected requests without a recipient. Shared swap URLs therefore loaded token metadata but never started a quote for disconnected users.

## Validation
- `bun run checks`
- `bun run --filter @x7/org build`
- Agent Browser: the reported ETH → X7R URL now returns a non-empty quote without a connected wallet
- Agent Browser: SPA chain switch from Ethereum/X7R to Base/USDC returns a Base quote
- Agent Browser: changing an in-flight amount from `0.3` to `0.4` only surfaces the final `0.4` quote
- unsupported URL chain IDs fall back without crashing the router provider
