### PR TITLE
fix(nav): dropdown menus open on hover and show their background

### DIFF
--- a/apps/org/src/app/(xchange)/_components/nav-items.tsx
+++ b/apps/org/src/app/(xchange)/_components/nav-items.tsx
@@ -78,7 +78,7 @@ export function NavItems() {
           >
             Liquidity
           </NavigationMenuTrigger>
-          <NavigationMenuContent className="border-0 border-none shadow-none ring-0">
+          <NavigationMenuContent>
             <ul className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
               <li className="row-span-3">
                 <NavigationMenuLink asChild>

--- a/packages/ui/src/navigation-menu.tsx
+++ b/packages/ui/src/navigation-menu.tsx
@@ -24,7 +24,7 @@ const NavigationMenuContext = React.createContext<NavigationMenuContextValue>({
 function NavigationMenu({
   className,
   children,
-  viewport = true,
+  viewport = false,
   ...props
 }: React.HTMLAttributes<HTMLElement> & {
   viewport?: boolean
@@ -111,6 +111,9 @@ function NavigationMenuTrigger({
   return (
     <BaseMenu.Trigger
       data-slot="navigation-menu-trigger"
+      openOnHover
+      delay={100}
+      closeDelay={100}
       className={cn(
         navigationMenuTriggerStyle(),
         "group cursor-pointer",
@@ -132,8 +135,6 @@ function NavigationMenuContent({
   className,
   ...props
 }: React.ComponentProps<typeof BaseMenu.Popup>) {
-  const { viewport } = React.useContext(NavigationMenuContext)
-
   return (
     <BaseMenu.Portal>
       <BaseMenu.Positioner>
@@ -141,11 +142,14 @@ function NavigationMenuContent({
           data-slot="navigation-menu-content"
           className={cn(
             "top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto",
+            // Panel chrome. base-ui always renders the content into this Popup
+            // (there is no shared Radix-style viewport), so the background,
+            // border and shadow must live here — otherwise the dropdown has no
+            // background.
+            "bg-popover text-popover-foreground mt-1.5 overflow-hidden rounded-md border shadow",
             "data-[starting-style]:opacity-0 data-[starting-style]:translate-y-1",
             "data-[ending-style]:opacity-0 data-[ending-style]:translate-y-1",
             "motion-safe:transition-[transform,opacity] motion-safe:duration-[220ms] motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-            !viewport &&
-              "bg-popover text-popover-foreground mt-1.5 overflow-hidden rounded-md border shadow",
             "**:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
             className
           )}


### PR DESCRIPTION
## Summary

Fixes two issues with the desktop navigation dropdowns (Liquidity / the middle menu / About): **no background** on the panel, and they only opened **on click** instead of hover.

## Root cause

The dropdowns are built on base-ui's `Menu`. Unlike Radix, base-ui renders the dropdown content into its own `Menu.Popup` rather than a shared "viewport" element. So:

- The panel `bg-popover`/border/shadow were only applied in the `!viewport` branch, but `viewport` **defaulted to `true`** — the Popup rendered with **no background**, and the `NavigationMenuViewport` `<div>` was dead, empty markup.
- Hover-open in base-ui is a **Trigger** prop; the trigger didn't set it, so menus opened on click only.

## Fix

- Apply the panel chrome (`bg-popover border shadow`) **unconditionally** on the Popup, and default `viewport` to `false` (stops rendering the empty viewport div).
- Add `openOnHover` + a small `delay`/`closeDelay` to `NavigationMenuTrigger`.
- Drop the `border-0 shadow-none ring-0` override on the Liquidity content so all three dropdowns share consistent chrome.

## Verification

Headless-browser check on the built app: hovering a nav item opens its dropdown (no click), and the panel renders with a solid background (`rgb(255,255,255)` / `bg-popover`) + 1px border. `bun run checks` 54/54.
